### PR TITLE
fix: use mailbox default ISM instead of hardcoded MultisigISM

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The main intent protocol that manages the complete intent lifecycle:
 A specialized program that integrates with Hyperlane for cross-chain message delivery:
 
 - **Cross-Chain Messaging**: Uses Hyperlane to send fulfillment notifications to source chains
-- **Message Validation**: Implements ISM (Interchain Security Module) for security
+- **Message Validation**: Uses Hyperlane's default ISM (Interchain Security Module) for message security — the prover does not configure a custom ISM, so the mailbox's default ISM is used for all incoming messages
 - **Account Management**: Manages proof accounts and cleanup operations
 
 ### How They Work Together
@@ -59,7 +59,7 @@ sequenceDiagram
 
 1. **Intent Lifecycle**: Portal manages the full intent creation, funding, and fulfillment process
 2. **Cross-Chain Messaging**: HyperProver handles Hyperlane message passing for proof delivery
-3. **Security**: Hyperlane's ISM validates cross-chain messages for security
+3. **Security**: Hyperlane's **default ISM** validates cross-chain messages — the HyperProver returns `None` for its ISM, deferring to the mailbox's configured default ISM
 4. **Cleanup**: Proof accounts are closed after successful validation to reclaim rent
 
 ### Key Features
@@ -254,7 +254,7 @@ A prover implementation for same-chain intents (e.g., Solana to Solana transacti
 
 ### Dummy ISM Program
 
-A simplified ISM implementation for testing cross-chain message validation in local environments.
+A simplified ISM implementation used as the mailbox's default ISM in local test environments, standing in for Hyperlane's real default ISM.
 
 ## Testing
 

--- a/integration-tests/tests/common/hyper_prover_context.rs
+++ b/integration-tests/tests/common/hyper_prover_context.rs
@@ -13,7 +13,7 @@ use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use solana_sdk::transaction::Transaction;
 
-use crate::common::{Context, TransactionResult};
+use crate::common::{sol_amount, Context, TransactionResult};
 
 #[derive(Deref, DerefMut)]
 pub struct HyperProver<'a>(&'a mut Context);
@@ -52,7 +52,51 @@ impl HyperProver<'_> {
     }
 
     pub fn ism_account_metas(&mut self) -> Vec<AccountMeta> {
-        vec![]
+        let ism_account_metas_pda = Pubkey::find_program_address(
+            &[
+                b"hyperlane_message_recipient",
+                b"-",
+                b"interchain_security_module",
+                b"-",
+                b"account_metas",
+            ],
+            &hyper_prover::ID,
+        )
+        .0;
+
+        let instruction = hyper_prover::instruction::IsmAccountMetas {};
+        let accounts = hyper_prover::accounts::IsmAccountMetas {
+            ism_account_metas: ism_account_metas_pda,
+        };
+
+        let instruction = Instruction {
+            program_id: hyper_prover::ID,
+            accounts: accounts.to_account_metas(None),
+            data: instruction.data(),
+        };
+
+        let payer = Keypair::new();
+        self.airdrop(&payer.pubkey(), sol_amount(1.0)).unwrap();
+
+        let transaction = Transaction::new(
+            &[&payer],
+            Message::new(&[instruction], Some(&payer.pubkey())),
+            self.latest_blockhash(),
+        );
+
+        let result = self.send_transaction(transaction).unwrap();
+
+        let serializable_metas: Vec<SerializableAccountMeta> =
+            BorshDeserialize::try_from_slice(&result.return_data.data).unwrap();
+
+        serializable_metas
+            .into_iter()
+            .map(|meta| AccountMeta {
+                pubkey: meta.pubkey,
+                is_signer: meta.is_signer,
+                is_writable: meta.is_writable,
+            })
+            .collect()
     }
 
     pub fn handle_account_metas(

--- a/integration-tests/tests/common/hyper_prover_context.rs
+++ b/integration-tests/tests/common/hyper_prover_context.rs
@@ -6,7 +6,6 @@ use eco_svm_std::prover::{ProofData, ProveArgs};
 use eco_svm_std::{Bytes32, SerializableAccountMeta};
 use hyper_prover::hyperlane;
 use hyper_prover::state::dispatcher_pda;
-// import hyper_prover
 use solana_sdk::instruction::Instruction;
 use solana_sdk::message::Message;
 use solana_sdk::pubkey::Pubkey;
@@ -14,7 +13,7 @@ use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use solana_sdk::transaction::Transaction;
 
-use crate::common::{sol_amount, Context, TransactionResult};
+use crate::common::{Context, TransactionResult};
 
 #[derive(Deref, DerefMut)]
 pub struct HyperProver<'a>(&'a mut Context);
@@ -53,51 +52,7 @@ impl HyperProver<'_> {
     }
 
     pub fn ism_account_metas(&mut self) -> Vec<AccountMeta> {
-        let ism_account_metas_pda = Pubkey::find_program_address(
-            &[
-                b"hyperlane_message_recipient",
-                b"-",
-                b"interchain_security_module",
-                b"-",
-                b"account_metas",
-            ],
-            &hyper_prover::ID,
-        )
-        .0;
-
-        let instruction = hyper_prover::instruction::IsmAccountMetas {};
-        let accounts = hyper_prover::accounts::IsmAccountMetas {
-            ism_account_metas: ism_account_metas_pda,
-        };
-
-        let instruction = Instruction {
-            program_id: hyper_prover::ID,
-            accounts: accounts.to_account_metas(None),
-            data: instruction.data(),
-        };
-
-        let payer = Keypair::new();
-        self.airdrop(&payer.pubkey(), sol_amount(1.0)).unwrap();
-
-        let transaction = Transaction::new(
-            &[&payer],
-            Message::new(&[instruction], Some(&payer.pubkey())),
-            self.latest_blockhash(),
-        );
-
-        let result = self.send_transaction(transaction).unwrap();
-
-        let serializable_metas: Vec<SerializableAccountMeta> =
-            BorshDeserialize::try_from_slice(&result.return_data.data).unwrap();
-
-        serializable_metas
-            .into_iter()
-            .map(|meta| AccountMeta {
-                pubkey: meta.pubkey,
-                is_signer: meta.is_signer,
-                is_writable: meta.is_writable,
-            })
-            .collect()
+        vec![]
     }
 
     pub fn handle_account_metas(

--- a/integration-tests/tests/common/hyperlane_context.rs
+++ b/integration-tests/tests/common/hyperlane_context.rs
@@ -3,7 +3,7 @@ use anchor_lang::prelude::{borsh, AccountMeta};
 use anchor_lang::{InstructionData, ToAccountMetas};
 use derive_more::{Deref, DerefMut};
 use eco_svm_std::CHAIN_ID;
-use hyper_prover::hyperlane::{process_authority_pda, MAILBOX_ID, MULTISIG_ISM_MESSAGE_ID};
+use hyper_prover::hyperlane::{process_authority_pda, MAILBOX_ID};
 use litesvm::LiteSVM;
 use solana_sdk::instruction::Instruction;
 use solana_sdk::message::Message;
@@ -20,7 +20,7 @@ const SPL_NOOP_BIN: &[u8] = include_bytes!("../../../bins/noop.so");
 
 pub fn add_hyperlane_programs(svm: &mut LiteSVM) {
     svm.add_program(MAILBOX_ID, MAILBOX_BIN);
-    svm.add_program(MULTISIG_ISM_MESSAGE_ID, DUMMY_ISM_BIN);
+    svm.add_program(dummy_ism::ID, DUMMY_ISM_BIN);
     svm.add_program(spl_noop::ID, SPL_NOOP_BIN);
 }
 
@@ -68,7 +68,7 @@ fn init_dummy_ism(svm: &mut LiteSVM) -> Pubkey {
     let initializer = Keypair::new();
     svm.airdrop(&initializer.pubkey(), sol_amount(1.0)).unwrap();
 
-    let ism_state_pda = Pubkey::find_program_address(&[b"ism_state"], &MULTISIG_ISM_MESSAGE_ID).0;
+    let ism_state_pda = Pubkey::find_program_address(&[b"ism_state"], &dummy_ism::ID).0;
 
     let init_instruction = dummy_ism::instruction::Init {};
     let accounts = dummy_ism::accounts::Init {
@@ -78,7 +78,7 @@ fn init_dummy_ism(svm: &mut LiteSVM) -> Pubkey {
     };
 
     let instruction = Instruction {
-        program_id: MULTISIG_ISM_MESSAGE_ID,
+        program_id: dummy_ism::ID,
         accounts: accounts.to_account_metas(None),
         data: init_instruction.data(),
     };
@@ -191,10 +191,6 @@ impl Hyperlane<'_> {
             AccountMeta::new_readonly(process_authority_pda, false),
             AccountMeta::new(processed_message_pda, false),
         ];
-        accounts.extend(
-            // 5: ISM account metas
-            self.hyper_prover().ism_account_metas(),
-        );
         accounts.extend(vec![
             // 6: SPL-noop
             AccountMeta::new_readonly(spl_noop::ID, false),

--- a/integration-tests/tests/common/hyperlane_context.rs
+++ b/integration-tests/tests/common/hyperlane_context.rs
@@ -25,8 +25,8 @@ pub fn add_hyperlane_programs(svm: &mut LiteSVM) {
 }
 
 pub fn init_hyperlane(svm: &mut LiteSVM) {
-    let dummy_ism_pda = init_dummy_ism(svm);
-    init_mailbox(svm, dummy_ism_pda);
+    init_dummy_ism(svm);
+    init_mailbox(svm, dummy_ism::ID);
 }
 
 #[derive(BorshDeserialize, BorshSerialize)]

--- a/integration-tests/tests/common/hyperlane_context.rs
+++ b/integration-tests/tests/common/hyperlane_context.rs
@@ -64,7 +64,7 @@ struct ProtocolFee {
     pub beneficiary: Pubkey,
 }
 
-fn init_dummy_ism(svm: &mut LiteSVM) -> Pubkey {
+fn init_dummy_ism(svm: &mut LiteSVM) {
     let initializer = Keypair::new();
     svm.airdrop(&initializer.pubkey(), sol_amount(1.0)).unwrap();
 
@@ -90,8 +90,6 @@ fn init_dummy_ism(svm: &mut LiteSVM) -> Pubkey {
     );
 
     svm.send_transaction(transaction).unwrap();
-
-    ism_state_pda
 }
 
 fn init_mailbox(svm: &mut LiteSVM, default_ism: Pubkey) {
@@ -191,6 +189,10 @@ impl Hyperlane<'_> {
             AccountMeta::new_readonly(process_authority_pda, false),
             AccountMeta::new(processed_message_pda, false),
         ];
+        accounts.extend(
+            // 5: ISM account metas
+            self.hyper_prover().ism_account_metas(),
+        );
         accounts.extend(vec![
             // 6: SPL-noop
             AccountMeta::new_readonly(spl_noop::ID, false),

--- a/programs/hyper-prover/src/hyperlane.rs
+++ b/programs/hyper-prover/src/hyperlane.rs
@@ -9,12 +9,8 @@ use crate::instructions::Prove;
 
 #[cfg(feature = "mainnet")]
 pub const MAILBOX_ID: Pubkey = pubkey!("E588QtVUvresuXq2KoNEwAmoifCzYGpRBdHByN9KQMbi");
-#[cfg(feature = "mainnet")]
-pub const MULTISIG_ISM_MESSAGE_ID: Pubkey = pubkey!("EpAuVN1oc5GccKAk41VMBHTgzJFtB5bftvi92SywQdbS");
 #[cfg(not(feature = "mainnet"))]
 pub const MAILBOX_ID: Pubkey = pubkey!("75HBBLae3ddeneJVrZeyrDfv6vb7SMC3aCpBucSXS5aR");
-#[cfg(not(feature = "mainnet"))]
-pub const MULTISIG_ISM_MESSAGE_ID: Pubkey = pubkey!("4GHxwWyKB9exhKG4fdyU2hfLgfFzhHp2WcsSKc2uNR1k");
 
 pub const HANDLE_DISCRIMINATOR: [u8; 8] = [33, 210, 5, 66, 196, 212, 239, 142];
 pub const HANDLE_ACCOUNT_METAS_DISCRIMINATOR: [u8; 8] = [194, 141, 30, 82, 241, 41, 169, 52];

--- a/programs/hyper-prover/src/instructions/ism.rs
+++ b/programs/hyper-prover/src/instructions/ism.rs
@@ -4,6 +4,9 @@ use anchor_lang::solana_program::program::set_return_data;
 #[derive(Accounts)]
 pub struct Ism {}
 
+/// Returns `None` as the ISM program ID, signalling to Hyperlane that this
+/// recipient has no custom Interchain Security Module. The mailbox will
+/// therefore fall back to its configured default ISM for message verification.
 pub fn ism(_ctx: Context<Ism>) -> Result<()> {
     set_return_data(None::<Pubkey>.try_to_vec()?.as_slice());
     Ok(())

--- a/programs/hyper-prover/src/instructions/ism.rs
+++ b/programs/hyper-prover/src/instructions/ism.rs
@@ -1,17 +1,10 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program::set_return_data;
 
-use crate::hyperlane;
-
 #[derive(Accounts)]
 pub struct Ism {}
 
 pub fn ism(_ctx: Context<Ism>) -> Result<()> {
-    set_return_data(
-        Some(hyperlane::MULTISIG_ISM_MESSAGE_ID)
-            .try_to_vec()?
-            .as_slice(),
-    );
-
+    set_return_data(None::<Pubkey>.try_to_vec()?.as_slice());
     Ok(())
 }

--- a/programs/hyper-prover/src/instructions/ism_account_metas.rs
+++ b/programs/hyper-prover/src/instructions/ism_account_metas.rs
@@ -1,9 +1,5 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program::set_return_data;
-use borsh::BorshSerialize;
-use eco_svm_std::SerializableAccountMeta;
-
-use crate::hyperlane;
 
 #[derive(Accounts)]
 pub struct IsmAccountMetas<'info> {
@@ -22,13 +18,6 @@ pub struct IsmAccountMetas<'info> {
 }
 
 pub fn ism_account_metas(_ctx: Context<IsmAccountMetas>) -> Result<()> {
-    let metas = vec![SerializableAccountMeta {
-        pubkey: hyperlane::MULTISIG_ISM_MESSAGE_ID,
-        is_signer: false,
-        is_writable: false,
-    }];
-
-    set_return_data(&metas.try_to_vec()?);
-
+    set_return_data(&[0, 0, 0, 0]); // borsh-serialized empty vec
     Ok(())
 }

--- a/programs/hyper-prover/src/instructions/ism_account_metas.rs
+++ b/programs/hyper-prover/src/instructions/ism_account_metas.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program::set_return_data;
+use eco_svm_std::SerializableAccountMeta;
 
 #[derive(Accounts)]
 pub struct IsmAccountMetas<'info> {
@@ -18,6 +19,7 @@ pub struct IsmAccountMetas<'info> {
 }
 
 pub fn ism_account_metas(_ctx: Context<IsmAccountMetas>) -> Result<()> {
-    set_return_data(&[0, 0, 0, 0]); // borsh-serialized empty vec
+    set_return_data(&Vec::<SerializableAccountMeta>::new().try_to_vec()?);
+
     Ok(())
 }

--- a/programs/hyper-prover/src/instructions/ism_account_metas.rs
+++ b/programs/hyper-prover/src/instructions/ism_account_metas.rs
@@ -18,6 +18,9 @@ pub struct IsmAccountMetas<'info> {
     pub ism_account_metas: AccountInfo<'info>,
 }
 
+/// Returns an empty list of account metas for the ISM. Because this recipient
+/// defers to Hyperlane's default ISM (no custom ISM is configured), no
+/// additional accounts are required for the ISM verification step.
 pub fn ism_account_metas(_ctx: Context<IsmAccountMetas>) -> Result<()> {
     set_return_data(&Vec::<SerializableAccountMeta>::new().try_to_vec()?);
 

--- a/programs/hyper-prover/src/lib.rs
+++ b/programs/hyper-prover/src/lib.rs
@@ -45,11 +45,17 @@ pub mod hyper_prover {
         instructions::handle_account_metas(ctx, origin, sender, payload)
     }
 
+    /// Called by Hyperlane to discover this recipient's ISM. Returns `None`,
+    /// indicating that the mailbox's default ISM should be used for message
+    /// verification rather than a custom ISM.
     #[instruction(discriminator = &hyperlane::INTERCHAIN_SECURITY_MODULE_DISCRIMINATOR)]
     pub fn ism(ctx: Context<Ism>) -> Result<()> {
         instructions::ism(ctx)
     }
 
+    /// Called by Hyperlane to discover the accounts required by this
+    /// recipient's ISM. Returns an empty list because no custom ISM is
+    /// configured; the mailbox's default ISM is used instead.
     #[instruction(discriminator = &hyperlane::INTERCHAIN_SECURITY_MODULE_ACCOUNT_METAS_DISCRIMINATOR)]
     pub fn ism_account_metas(ctx: Context<IsmAccountMetas>) -> Result<()> {
         instructions::ism_account_metas(ctx)


### PR DESCRIPTION
## Goal

Stop hardcoding a specific MultisigISM address in the HyperProver. Instead, delegate ISM selection to the HyperLane mailbox's default ISM — which HyperLane maintains and rotates automatically.

This eliminates the need to redeploy the HyperProver program every time HyperLane rotates MultisigISM validators.

## Before / After

```mermaid
flowchart LR
    subgraph before [Before]
        direction TB
        MB1[Mailbox] -->|"which ISM?"| HP1[HyperProver]
        HP1 -->|"use 0xABC..."| MB1
        MB1 -->|verify| ISM1["MultisigISM\n(hardcoded)"]
    end

    subgraph after [After]
        direction TB
        MB2[Mailbox] -->|"which ISM?"| HP2[HyperProver]
        HP2 -->|"None"| MB2
        MB2 -->|verify| ISM2["Mailbox Default ISM\n(auto-rotated)"]
    end

    before ~~~ after
```

## Test plan

- [x] `cargo build` passes (default + `mainnet` feature)
- [x] Zero remaining references to `MULTISIG_ISM_MESSAGE_ID`