### PR TITLE
fix(flash-fulfiller): report documented delta as native_fee, not swept amount

### DIFF
--- a/integration-tests/tests/flash_fulfill.rs
+++ b/integration-tests/tests/flash_fulfill.rs
@@ -175,7 +175,7 @@ fn flash_fulfill_native_fee_reports_documented_delta_not_swept_amount() {
     let donation: u64 = 7777;
     ctx.airdrop(&flash_vault_pda().0, donation).unwrap();
 
-    let documented_delta = reward.native_amount - route.native_amount;
+    let documented_delta = reward.native_amount.saturating_sub(route.native_amount);
 
     let claimant_ata_metas = claimant_atas(&ctx, &reward, claimant);
     let result = ctx.flash_fulfiller().flash_fulfill(

--- a/integration-tests/tests/flash_fulfill.rs
+++ b/integration-tests/tests/flash_fulfill.rs
@@ -164,6 +164,43 @@ fn flash_fulfill_should_succeed() {
 }
 
 #[test]
+fn flash_fulfill_native_fee_reports_documented_delta_not_swept_amount() {
+    let (mut ctx, route, reward, _vault) = setup();
+    let intent_hash_value = intent_hash(CHAIN_ID, &route.hash(), &reward.hash());
+    let claimant = Pubkey::new_unique();
+    reward.tokens.iter().for_each(|token| {
+        ctx.airdrop_token_ata(&token.token, &claimant, 0);
+    });
+
+    let donation: u64 = 7777;
+    ctx.airdrop(&flash_vault_pda().0, donation).unwrap();
+
+    let documented_delta = reward.native_amount - route.native_amount;
+
+    let claimant_ata_metas = claimant_atas(&ctx, &reward, claimant);
+    let result = ctx.flash_fulfiller().flash_fulfill(
+        FlashFulfillIntent::Intent {
+            route: route.clone(),
+            reward: reward.clone(),
+        },
+        None,
+        &route,
+        &reward,
+        claimant,
+        claimant_ata_metas,
+        vec![],
+    );
+
+    assert!(result.is_ok_and(common::contains_cpi_event(FlashFulfilled {
+        intent_hash: intent_hash_value,
+        claimant,
+        native_fee: documented_delta,
+    })));
+    assert_eq!(ctx.balance(&claimant), documented_delta + donation);
+    assert_eq!(ctx.balance(&flash_vault_pda().0), 0);
+}
+
+#[test]
 fn flash_fulfill_default_claimant_fail() {
     let (mut ctx, route, reward, _) = setup();
     let claimant = Pubkey::default();

--- a/programs/flash-fulfiller/src/events.rs
+++ b/programs/flash-fulfiller/src/events.rs
@@ -8,6 +8,10 @@ pub struct FlashFulfilled {
     pub intent_hash: Bytes32,
     /// Recipient of leftover tokens and native SOL.
     pub claimant: Pubkey,
-    /// Native SOL swept to the claimant (`reward.native_amount - route.native_amount`).
+    /// Solver's native SOL profit on this intent: `reward.native_amount -
+    /// route.native_amount` (saturating). This is the documented intent
+    /// delta, not the actual lamports swept from `flash_vault` to the
+    /// claimant — pre-funded lamports on the system-owned PDA are also
+    /// swept but are not reflected here.
     pub native_fee: u64,
 }

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -140,6 +140,7 @@ pub fn flash_fulfill<'info>(
     let route_hash = route.hash();
     let reward_hash = reward.hash();
     let intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
+    let native_fee = reward.native_amount.saturating_sub(route.native_amount);
     let flash_vault = ctx.accounts.flash_vault.key();
     let (_, flash_vault_bump) = flash_vault_pda();
     let flash_vault_seeds: &[&[u8]] = &[FLASH_VAULT_SEED, &[flash_vault_bump]];
@@ -216,7 +217,7 @@ pub fn flash_fulfill<'info>(
     )?;
 
     sweep_leftover_tokens(&ctx, &claimant_transfers, flash_vault_seeds)?;
-    let native_fee = sweep_leftover_native(&ctx, flash_vault_seeds)?;
+    sweep_leftover_native(&ctx, flash_vault_seeds)?;
 
     // Gate close on the IntentHash variant. Without this, a caller using the
     // inline `Intent { route, reward }` variant could pass any other writer's
@@ -395,10 +396,10 @@ fn sweep_leftover_tokens<'info>(
 fn sweep_leftover_native<'info>(
     ctx: &Context<'_, '_, '_, 'info, FlashFulfill<'info>>,
     flash_vault_seeds: &[&[u8]],
-) -> Result<u64> {
+) -> Result<()> {
     let leftover = ctx.accounts.flash_vault.lamports();
     if leftover == 0 {
-        return Ok(0);
+        return Ok(());
     }
 
     invoke_signed(
@@ -415,7 +416,7 @@ fn sweep_leftover_native<'info>(
         &[flash_vault_seeds],
     )?;
 
-    Ok(leftover)
+    Ok(())
 }
 
 fn resolve_intent(


### PR DESCRIPTION
## Summary

Audit finding from Rikard Hjort: \`FlashFulfilled.native_fee\` is documented as \`reward.native_amount - route.native_amount\` but actually emits the full \`flash_vault\` balance at sweep time. Since \`flash_vault\` is a system-owned PDA, anyone (including the solver themselves) can pre-fund it with arbitrary SOL, and that donation comes back through the sweep — inflating the reported fee. Downstream consumers treating the field as solver profit get garbage.

## Fix

Capture \`native_fee = reward.native_amount.saturating_sub(route.native_amount)\` BEFORE \`reward\` and \`route\` are moved into the \`WithdrawArgs\` / \`FulfillArgs\` CPI calls, and emit that.

**Sweep behavior unchanged** — \`flash_vault\` is still fully drained to \`claimant\` so any donation/dust still ends up with the claimant rather than locked in the PDA. Only the event field changes.

\`sweep_leftover_native\`'s \`Result<u64>\` return becomes \`Result<()>\` since the swept amount is no longer consumed.

\`saturating_sub\` is the safe choice — if \`route.native_amount > reward.native_amount\` (intent isn't profitable; shouldn't happen but BPF release wraps silently), we report 0 instead of a huge number.

## Test plan

- [ ] CI green (anchor build, fmt, clippy, cargo-sort, tests).
- [ ] New regression test \`flash_fulfill_native_fee_reports_documented_delta_not_swept_amount\` pre-funds \`flash_vault\` with 7777 lamports of donation, then runs \`flash_fulfill\`. Asserts \`FlashFulfilled.native_fee\` equals the documented delta (donation excluded), claimant receives \`delta + donation\` (sweep still drains the donation), \`flash_vault\` ends at 0 lamports.

## Stack

Based on #51 (mainnet readiness). Will auto-rebase to main once the upstream stack (#49 → #50 → #51) lands.