### PR TITLE
feat(ci): add semantic-release-driven release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  RUST_VERSION: "1.85.1"
+  ANCHOR_VERSION: "0.31.1"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          rust-version: ${{ env.RUST_VERSION }}
+          cache-key-suffix: release
+
+      - name: Setup Anchor
+        uses: ./.github/actions/setup-anchor
+        with:
+          anchor-version: ${{ env.ANCHOR_VERSION }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Compute next version (dry run)
+        id: dry
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          dry_run: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bump Cargo.toml versions (runner-only, never committed)
+        if: steps.dry.outputs.new_release_published == 'true'
+        run: scripts/bump-cargo-versions.sh ${{ steps.dry.outputs.new_release_version }}
+
+      - name: Build mainnet IDLs
+        if: steps.dry.outputs.new_release_published == 'true'
+        run: |
+          rm -rf target/idl
+          anchor run build-mainnet
+          mkdir -p dist/idl/mainnet
+          for program in portal hyper_prover local_prover flash_fulfiller proof_helper; do
+            cp "target/idl/${program}.json" "dist/idl/mainnet/${program}.json"
+          done
+
+      - name: Build devnet IDLs
+        if: steps.dry.outputs.new_release_published == 'true'
+        run: |
+          rm -rf target/idl
+          anchor run build-devnet
+          mkdir -p dist/idl/devnet
+          for program in portal hyper_prover local_prover flash_fulfiller proof_helper; do
+            cp "target/idl/${program}.json" "dist/idl/devnet/${program}.json"
+          done
+
+      - name: Release
+        id: semantic
+        if: steps.dry.outputs.new_release_published == 'true'
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create maintenance branch
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          VERSION="${{ steps.semantic.outputs.new_release_version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          BRANCH="releases/${MAJOR}.${MINOR}.x"
+          git push origin "refs/tags/v${VERSION}:refs/heads/${BRANCH}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .anchor
 CLAUDE.md
 /docs
+/dist

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,22 @@
+{
+  "branches": [
+    "main",
+    {
+      "name": "releases/+([0-9]).+([0-9]).x",
+      "range": "${name.replace('releases/', '')}"
+    }
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/github",
+      {
+        "assets": [
+          { "path": "dist/idl/mainnet/*.json", "label": "mainnet IDL — ${nextRelease.gitTag}" },
+          { "path": "dist/idl/devnet/*.json", "label": "devnet IDL — ${nextRelease.gitTag}" }
+        ]
+      }
+    ]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A cross-chain intent protocol built on Solana, enabling users to create intents 
 - [Programs](#programs)
 - [Testing](#testing)
 - [Deployment](#deployment)
+- [Release](#release)
 - [Contributing](#contributing)
 
 ## Architecture Overview
@@ -454,6 +455,53 @@ Update `Anchor.toml` for different environments:
 cluster = "localnet"  # or "devnet", "mainnet"
 wallet = "~/.config/solana/id.json"
 ```
+
+## Release
+
+Releases are published via the manual `Release` GitHub Actions workflow (`.github/workflows/release.yml`) — there is **no auto-release on push to `main`**. To cut a release, open the Actions tab on GitHub and click **Run workflow**.
+
+### What gets published
+
+Each release attaches mainnet and devnet IDLs as downloadable assets on the GitHub Release:
+
+```
+dist/idl/mainnet/{portal,hyper_prover,local_prover,flash_fulfiller,proof_helper}.json
+dist/idl/devnet/{portal,hyper_prover,local_prover,flash_fulfiller,proof_helper}.json
+```
+
+`dummy-ism` is excluded — it's a test-only program and never shipped.
+
+### Versioning
+
+Driven by [semantic-release](https://semantic-release.gitbook.io/) reading conventional-commit history since the last tag:
+
+| Commit type                        | Bump  |
+| ---------------------------------- | ----- |
+| `feat:` / `feat(scope):`           | minor |
+| `fix:` / `fix(scope):`             | patch |
+| `feat!:` or `BREAKING CHANGE:`     | major |
+| `chore:` / `docs:` / `refactor:` … | none  |
+
+If only `chore:`/`docs:` commits accumulated since the last tag, the workflow exits cleanly and creates no release.
+
+The `version` field in each released crate's `Cargo.toml` (the 5 production programs + `eco-svm-std`) is bumped on the CI runner *before* the IDL build by `scripts/bump-cargo-versions.sh`, so the published IDLs carry the correct `metadata.version`. **Those bumps are never committed back to source** — Cargo.tomls in `main` and `releases/*` stay at their pre-release version forever; the canonical version is the git tag, not the manifest. `dummy-ism` is not bumped.
+
+### First release
+
+semantic-release defaults to `1.0.0` for the first release when no prior version tag exists. To start in `0.x` land instead, push an initial tag before triggering the workflow:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Subsequent releases bump from that tag based on commits.
+
+### Maintenance branches
+
+After every successful release, the workflow automatically pushes a `releases/<major>.<minor>.x` branch (e.g. `releases/1.2.x`) pointing at the new tag. To back-port a patch onto an older minor line, check that branch out, cherry-pick or commit the fix, push, then re-run the Release workflow from the Actions UI with the **Use workflow from** branch selector set to `releases/<major>.<minor>.x`.
+
+semantic-release scopes the version bump to that line (so a `fix:` on `releases/1.2.x` produces `v1.2.1`, never `v1.3.x`).
 
 ## Contributing
 

--- a/scripts/bump-cargo-versions.sh
+++ b/scripts/bump-cargo-versions.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version>" >&2
+    exit 1
+fi
+
+released_crates=(
+    programs/flash-fulfiller/Cargo.toml
+    programs/hyper-prover/Cargo.toml
+    programs/local-prover/Cargo.toml
+    programs/portal/Cargo.toml
+    programs/proof-helper/Cargo.toml
+    packages/eco-svm-std/Cargo.toml
+)
+
+for manifest in "${released_crates[@]}"; do
+    awk -v ver="$VERSION" '
+        /^\[/ { in_package = ($0 == "[package]") }
+        in_package && /^version = / { sub(/".*"/, "\"" ver "\"") }
+        { print }
+    ' "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+done
+
+cargo update --workspace


### PR DESCRIPTION
## Summary

Adds a manual GitHub Release pipeline driven by [semantic-release](https://semantic-release.gitbook.io/), modeled after the company's other repos (cycjimmy/semantic-release-action) but with `workflow_dispatch`-only triggering — no auto-release on push to main.

## What it does

- **Trigger**: Manual via the Actions tab → "Run workflow." Concurrency-grouped so two clicks can't race.
- **Build**: Two passes — `anchor run build-mainnet` (with `--features mainnet`) and `anchor run build-devnet` — emitting IDLs into `dist/idl/{mainnet,devnet}/` for the 5 production programs (`portal`, `hyper-prover`, `local-prover`, `flash-fulfiller`, `proof-helper`).
- **Versioning**: semantic-release reads conventional-commit history since the last tag → `feat:` minor, `fix:` patch, `feat!:`/`BREAKING CHANGE:` major. `chore:`/`docs:`/`refactor:` accumulate without firing a release.
- **Cargo.toml sync**: `scripts/bump-cargo-versions.sh` updates the `version` field across the 5 programs + `eco-svm-std`. Intentionally skips `dummy-ism` (test-only, never shipped).
- **GitHub Release**: Auto-generated changelog + IDLs attached as downloadable assets, labeled per environment.

## Files

- `.github/workflows/release.yml` — workflow_dispatch entry point.
- `.releaserc.json` — semantic-release plugin config (commit-analyzer, release-notes-generator, exec, git, github).
- `scripts/bump-cargo-versions.sh` — Cargo.toml version sync (released crates only).
- `.gitignore` — adds `/dist`.
- `README.md` — new "Release" section documenting the flow + first-release / maintenance-branch guidance.

## First release

semantic-release defaults to `v1.0.0` for the first release. To stay in 0.x land, pre-seed an initial tag before triggering:

```bash
git tag v0.1.0
git push origin v0.1.0
```

## Test plan

- [ ] Smoke-tested `scripts/bump-cargo-versions.sh` locally (bumps then reverts cleanly; `dummy-ism` untouched; `cargo update --workspace` syncs `Cargo.lock`).
- [ ] Validated `release.yml` YAML and `.releaserc.json` parse.
- [ ] CI pr-checks green on this branch.
- [ ] After merge, do a dry-run release on a throwaway tag to verify the GH Actions flow end-to-end before the real first release.