### PR TITLE
fix(ci): suffix IDL asset basenames with environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           anchor run build-mainnet
           mkdir -p dist/idl/mainnet
           for program in portal hyper_prover local_prover flash_fulfiller proof_helper; do
-            cp "target/idl/${program}.json" "dist/idl/mainnet/${program}.json"
+            cp "target/idl/${program}.json" "dist/idl/mainnet/${program}.mainnet.json"
           done
 
       - name: Build devnet IDLs
@@ -69,7 +69,7 @@ jobs:
           anchor run build-devnet
           mkdir -p dist/idl/devnet
           for program in portal hyper_prover local_prover flash_fulfiller proof_helper; do
-            cp "target/idl/${program}.json" "dist/idl/devnet/${program}.json"
+            cp "target/idl/${program}.json" "dist/idl/devnet/${program}.devnet.json"
           done
 
       - name: Release


### PR DESCRIPTION
## Summary

The first release attempt (run [25414961531](https://github.com/eco/eco-routes-svm/actions/runs/25414961531/job/74544467649)) failed at the 6th asset upload with `422 Validation Failed: ReleaseAsset already_exists field: name`. Cause: GitHub uses the file's basename as the asset name on a release, and both `dist/idl/mainnet/portal.json` and `dist/idl/devnet/portal.json` resolve to the same upload name `portal.json` — the second collides.

Fix: rename at copy time so mainnet IDLs become `${program}.mainnet.json` and devnet IDLs become `${program}.devnet.json`. Each asset gets a unique basename; the `dist/idl/{mainnet,devnet}/*.json` globs in `.releaserc.json` keep working unchanged.

## Cleanup of failed run

- Draft release `v1.0.0` deleted.
- Tag `v1.0.0` deleted from origin.
- No orphan `releases/*` branch was created (workflow died before that step).

So the next release run can proceed cleanly from `v1.0.0` once this is merged.

## Test plan

- [ ] CI green.
- [ ] Re-trigger Release workflow from main after merge → expect 10 IDL assets (5 mainnet + 5 devnet) all uploaded with distinct names.