### PR TITLE
perf(flash-fulfiller): reduce pre-Portal CU consumption by ~80-150K

### DIFF
--- a/integration-tests/tests/flash_fulfill.rs
+++ b/integration-tests/tests/flash_fulfill.rs
@@ -1,4 +1,3 @@
-use anchor_lang::error::ErrorCode;
 use anchor_lang::prelude::AccountMeta;
 use anchor_lang::{AnchorSerialize, Discriminator};
 use anchor_spl::associated_token::get_associated_token_address_with_program_id;
@@ -381,7 +380,9 @@ fn flash_fulfill_intent_hash_missing_buffer_fail() {
         vec![],
     );
 
-    assert!(result.is_err_and(common::is_error(ErrorCode::AccountNotInitialized)));
+    assert!(result.is_err_and(common::is_error(
+        FlashFulfillerError::InvalidFlashFulfillIntentAccount
+    )));
 }
 
 #[test]

--- a/programs/flash-fulfiller/src/instructions/close_flash_fulfill_intent.rs
+++ b/programs/flash-fulfiller/src/instructions/close_flash_fulfill_intent.rs
@@ -1,8 +1,7 @@
 use anchor_lang::prelude::*;
-use anchor_lang::system_program;
 use eco_svm_std::Bytes32;
 
-use crate::instructions::FlashFulfillerError;
+use crate::instructions::{close_buffer, FlashFulfillerError};
 use crate::state::FLASH_FULFILL_INTENT_SEED;
 
 /// Args for [`close_flash_fulfill_intent`]: the intent hash identifying the
@@ -46,15 +45,5 @@ pub fn close_flash_fulfill_intent(
     ctx: Context<CloseFlashFulfillIntent>,
     _args: CloseFlashFulfillIntentArgs,
 ) -> Result<()> {
-    let buffer = ctx.accounts.flash_fulfill_intent.to_account_info();
-    let writer = ctx.accounts.writer.to_account_info();
-
-    let dest_starting_lamports = writer.lamports();
-    **writer.lamports.borrow_mut() = dest_starting_lamports
-        .checked_add(buffer.lamports())
-        .expect("lamport sum cannot overflow u64");
-    **buffer.lamports.borrow_mut() = 0;
-
-    buffer.assign(&system_program::ID);
-    buffer.realloc(0, false).map_err(Into::into)
+    close_buffer(&ctx.accounts.flash_fulfill_intent, &ctx.accounts.writer)
 }

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -318,6 +318,14 @@ fn init_flash_vault_reward_ata<'info>(
     ctx: &Context<'_, '_, '_, 'info, FlashFulfill<'info>>,
     transfer: &TokenTransferAccounts<'info>,
 ) -> Result<()> {
+    // Short-circuit: if the ATA already exists, the SPL-level idempotent op is
+    // a no-op anyway, but the CPI itself still costs ~5-15K CU. The PDA
+    // derivation is deterministic and ownership is verified downstream by the
+    // SPL Token transfer, so it is safe to skip when data is non-empty.
+    if !transfer.to.data_is_empty() {
+        return Ok(());
+    }
+
     let token_program = transfer.token_program(
         &ctx.accounts.token_program,
         &ctx.accounts.token_2022_program,

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -56,15 +56,16 @@ pub struct FlashFulfill<'info> {
     /// CHECK: declared as `UncheckedAccount` (not `Account<_, FlashFulfillIntentAccount>`)
     /// to skip Anchor's auto owner-check + discriminator-check + Borsh deserialize on
     /// instruction entry, since this account is unused for the inline `Intent` variant
-    /// and we want a single deserialize at consume time. The full security boundary —
-    /// owner == this program, first 8 bytes match `FlashFulfillIntentAccount`'s
-    /// discriminator, and the PDA re-derives from `(writer, intent_hash)` — is enforced
-    /// manually in `resolve_intent` before any field of the buffer is trusted. Closed
-    /// manually at the end of the handler when present, refunding rent to `writer`.
-    /// The `writer` account is validated transitively by the PDA re-derivation in
-    /// `resolve_intent`. Anchor does not support `Option<NestedAccounts>` (composite
-    /// Optionals), so the bundle is expressed as two separate Optionals plus a runtime
-    /// "both or neither" check in the handler.
+    /// and we want a single deserialize at consume time. The full security boundary is
+    /// enforced manually in `resolve_intent` before any field of the buffer is trusted:
+    /// (1) owner == this program, (2) `data.len() >= 8`, (3) first 8 bytes match
+    /// `FlashFulfillIntentAccount`'s discriminator, (4) the PDA re-derives from
+    /// `(writer, intent_hash)`, and (5) the recomputed `intent_hash` matches the
+    /// seed-supplied one. Closed manually at the end of the handler when present,
+    /// refunding rent to `writer`. The `writer` account is validated transitively by
+    /// the PDA re-derivation in `resolve_intent`. Anchor does not support
+    /// `Option<NestedAccounts>` (composite Optionals), so the bundle is expressed as
+    /// two separate Optionals plus a runtime "both or neither" check in the handler.
     #[account(mut)]
     pub flash_fulfill_intent: Option<UncheckedAccount<'info>>,
     /// CHECK: validated transitively by the buffer PDA re-derivation in
@@ -300,10 +301,9 @@ fn init_flash_vault_reward_ata<'info>(
     ctx: &Context<'_, '_, '_, 'info, FlashFulfill<'info>>,
     transfer: &TokenTransferAccounts<'info>,
 ) -> Result<()> {
-    // Short-circuit: if the ATA already exists, the SPL-level idempotent op is
-    // a no-op anyway, but the CPI itself still costs ~5-15K CU. The PDA
-    // derivation is deterministic and ownership is verified downstream by the
-    // SPL Token transfer, so it is safe to skip when data is non-empty.
+    // The `create` CPI below is non-idempotent — it errors on an already-initialized
+    // ATA. This guard turns it into a no-op when the ATA exists. Downstream SPL
+    // transfer re-verifies ownership, so skipping the create is safe.
     if !transfer.to.data_is_empty() {
         return Ok(());
     }
@@ -453,31 +453,25 @@ fn resolve_intent(
                 .as_ref()
                 .ok_or(FlashFulfillerError::WriterRequired)?;
 
-            // Owner check: the buffer wrapper is now `UncheckedAccount`, so Anchor no
-            // longer auto-verifies the account is owned by this program. Without this
-            // check, a caller could pass a system-program-owned (or other-program-owned)
-            // account whose contents happen to deserialize as `FlashFulfillIntentAccount`.
+            // UncheckedAccount skips Anchor's auto owner-check; without this, a
+            // foreign-owned account whose bytes happen to deserialize as
+            // `FlashFulfillIntentAccount` would slip through.
             require!(
                 buffer.owner == &crate::ID,
                 FlashFulfillerError::InvalidFlashFulfillIntentAccount
             );
 
             let data = buffer.try_borrow_data()?;
-            // Discriminator-length check: needed before slicing `data[..8]`. Catches
-            // freshly-created uninitialized buffers (size 0) and undersized accounts.
+            // Required before slicing `data[..8]` — catches uninitialized buffers (size 0).
             require!(
                 data.len() >= 8,
                 FlashFulfillerError::InvalidFlashFulfillIntentAccount
             );
-            // Discriminator check: Anchor previously enforced that the first 8 bytes
-            // identify this exact account type. Now done manually using the
-            // `DISCRIMINATOR` const exposed by `#[account]` (Anchor 0.30+).
             require!(
                 &data[..8] == FlashFulfillIntentAccount::DISCRIMINATOR,
                 FlashFulfillerError::InvalidFlashFulfillIntentAccount
             );
-            // Borsh deserialize: replaces the auto-deserialize Anchor's `Account<_, T>`
-            // did on entry. Done once here; no re-serialize at exit since the buffer
+            // Single deserialize at consume time — no exit-serialize since the buffer
             // is closed at the end of the handler.
             let intent_account: FlashFulfillIntentAccount =
                 AnchorDeserialize::deserialize(&mut &data[8..])?;

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -53,15 +53,20 @@ pub struct FlashFulfill<'info> {
     /// CHECK: address is validated
     #[account(mut, address = flash_vault_pda().0 @ FlashFulfillerError::InvalidFlashVault)]
     pub flash_vault: UncheckedAccount<'info>,
-    /// CHECK: only read for the IntentHash variant; address validated in handler.
-    /// Closed manually at the end of the handler when present, refunding rent
-    /// to `writer`. The `writer` account is validated transitively by the PDA
-    /// re-derivation in `resolve_intent`. Anchor does not support
-    /// `Option<NestedAccounts>` (composite Optionals), so the bundle is
-    /// expressed as two separate Optionals plus a runtime "both or neither"
-    /// check in the handler.
+    /// CHECK: declared as `UncheckedAccount` (not `Account<_, FlashFulfillIntentAccount>`)
+    /// to skip Anchor's auto owner-check + discriminator-check + Borsh deserialize on
+    /// instruction entry, since this account is unused for the inline `Intent` variant
+    /// and we want a single deserialize at consume time. The full security boundary —
+    /// owner == this program, first 8 bytes match `FlashFulfillIntentAccount`'s
+    /// discriminator, and the PDA re-derives from `(writer, intent_hash)` — is enforced
+    /// manually in `resolve_intent` before any field of the buffer is trusted. Closed
+    /// manually at the end of the handler when present, refunding rent to `writer`.
+    /// The `writer` account is validated transitively by the PDA re-derivation in
+    /// `resolve_intent`. Anchor does not support `Option<NestedAccounts>` (composite
+    /// Optionals), so the bundle is expressed as two separate Optionals plus a runtime
+    /// "both or neither" check in the handler.
     #[account(mut)]
-    pub flash_fulfill_intent: Option<Account<'info, FlashFulfillIntentAccount>>,
+    pub flash_fulfill_intent: Option<UncheckedAccount<'info>>,
     /// CHECK: validated transitively by the buffer PDA re-derivation in
     /// `resolve_intent`. Required when `FlashFulfillIntent::IntentHash` is used
     /// (the buffer's rent refund target); omitted with the inline `Intent`
@@ -125,7 +130,7 @@ pub struct FlashFulfill<'info> {
 /// support `Option<NestedAccounts>`, so the pairing is enforced at runtime
 /// (`WriterRequired` if buffer is supplied without writer).
 pub fn flash_fulfill<'info>(
-    mut ctx: Context<'_, '_, '_, 'info, FlashFulfill<'info>>,
+    ctx: Context<'_, '_, '_, 'info, FlashFulfill<'info>>,
     args: FlashFulfillArgs,
 ) -> Result<()> {
     let FlashFulfillArgs { intent } = args;
@@ -136,7 +141,7 @@ pub fn flash_fulfill<'info>(
     );
 
     let should_close = matches!(intent, FlashFulfillIntent::IntentHash(_));
-    let (route, reward, route_hash, reward_hash, intent_hash) = resolve_intent(&mut ctx, intent)?;
+    let (route, reward, route_hash, reward_hash, intent_hash) = resolve_intent(&ctx, intent)?;
     let native_fee = reward.native_amount.saturating_sub(route.native_amount);
     let flash_vault = ctx.accounts.flash_vault.key();
     let (_, flash_vault_bump) = flash_vault_pda();
@@ -231,7 +236,26 @@ pub fn flash_fulfill<'info>(
             ctx.accounts.writer.as_ref().expect(
                 "writer must be Some when intent is IntentHash (validated in resolve_intent)",
             );
-        buffer.close(writer.to_account_info())?;
+        // Manual replication of Anchor's `Account::close` for an `UncheckedAccount`,
+        // since the buffer is no longer wrapped by `Account<_, T>`. Sequence:
+        //   1. Drain lamports from `buffer` into `writer` (rent refund target).
+        //   2. Zero the 8-byte discriminator so any code path that re-reads the
+        //      account in the same tx cannot match a `FlashFulfillIntentAccount`.
+        //   3. Realloc data to 0 bytes.
+        //   4. Reassign ownership to the system program — completes the close.
+        let dest_starting_lamports = writer.lamports();
+        **writer.lamports.borrow_mut() = dest_starting_lamports
+            .checked_add(buffer.lamports())
+            .ok_or(FlashFulfillerError::BufferLengthOverflow)?;
+        **buffer.lamports.borrow_mut() = 0;
+        {
+            let mut data = buffer.try_borrow_mut_data()?;
+            if data.len() >= 8 {
+                data[..8].fill(0);
+            }
+        }
+        buffer.realloc(0, false)?;
+        buffer.assign(&anchor_lang::system_program::ID);
     }
 
     emit_cpi!(FlashFulfilled {
@@ -417,7 +441,7 @@ fn sweep_leftover_native<'info>(
 }
 
 fn resolve_intent(
-    ctx: &mut Context<FlashFulfill>,
+    ctx: &Context<FlashFulfill>,
     intent: FlashFulfillIntent,
 ) -> Result<(Route, Reward, Bytes32, Bytes32, Bytes32)> {
     match intent {
@@ -428,16 +452,46 @@ fn resolve_intent(
             Ok((route, reward, route_hash, reward_hash, intent_hash))
         }
         FlashFulfillIntent::IntentHash(intent_hash) => {
-            let intent = ctx
+            let buffer = ctx
                 .accounts
                 .flash_fulfill_intent
-                .as_mut()
+                .as_ref()
                 .ok_or(FlashFulfillerError::InvalidFlashFulfillIntentAccount)?;
             let writer = ctx
                 .accounts
                 .writer
                 .as_ref()
                 .ok_or(FlashFulfillerError::WriterRequired)?;
+
+            // Owner check: the buffer wrapper is now `UncheckedAccount`, so Anchor no
+            // longer auto-verifies the account is owned by this program. Without this
+            // check, a caller could pass a system-program-owned (or other-program-owned)
+            // account whose contents happen to deserialize as `FlashFulfillIntentAccount`.
+            require!(
+                buffer.owner == &crate::ID,
+                FlashFulfillerError::InvalidFlashFulfillIntentAccount
+            );
+
+            let data = buffer.try_borrow_data()?;
+            // Discriminator-length check: needed before slicing `data[..8]`. Catches
+            // freshly-created uninitialized buffers (size 0) and undersized accounts.
+            require!(
+                data.len() >= 8,
+                FlashFulfillerError::InvalidFlashFulfillIntentAccount
+            );
+            // Discriminator check: Anchor previously enforced that the first 8 bytes
+            // identify this exact account type. Now done manually using the
+            // `DISCRIMINATOR` const exposed by `#[account]` (Anchor 0.30+).
+            require!(
+                &data[..8] == FlashFulfillIntentAccount::DISCRIMINATOR,
+                FlashFulfillerError::InvalidFlashFulfillIntentAccount
+            );
+            // Borsh deserialize: replaces the auto-deserialize Anchor's `Account<_, T>`
+            // did on entry. Done once here; no re-serialize at exit since the buffer
+            // is closed at the end of the handler.
+            let intent_account: FlashFulfillIntentAccount =
+                AnchorDeserialize::deserialize(&mut &data[8..])?;
+            drop(data);
 
             // Security boundary: the writer account is the rent-refund target, so we
             // must verify it actually owns this buffer's PDA. The seed binding
@@ -447,41 +501,22 @@ fn resolve_intent(
             // buffer.key(). Without this re-derivation, any pubkey could be supplied
             // as `writer` and redirect the close-rent refund.
             require!(
-                intent.key() == FlashFulfillIntentAccount::pda(&writer.key(), &intent_hash).0,
+                buffer.key() == FlashFulfillIntentAccount::pda(&writer.key(), &intent_hash).0,
                 FlashFulfillerError::InvalidFlashFulfillIntentAccount
             );
             // `append_flash_fulfill_intent_chunk` does not validate streamed bytes
             // against the seed `intent_hash` — without this check, `args.intent_hash`
             // and the intent actually fulfilled (recomputed from the buffer downstream)
             // could diverge silently.
-            let route_hash = intent.route.hash();
-            let reward_hash = intent.reward.hash();
+            let FlashFulfillIntentAccount { route, reward } = intent_account;
+            let route_hash = route.hash();
+            let reward_hash = reward.hash();
             let computed_intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
             require!(
                 intent_hash == computed_intent_hash,
                 FlashFulfillerError::InvalidFlashFulfillIntentAccount
             );
 
-            // The buffer is closed at the end of the handler, so move the Vec
-            // payloads out of it instead of cloning the (potentially ~2.5 KB)
-            // Route + Reward. Small Copy fields are read inline; only the Vec
-            // fields go through `mem::take` to avoid requiring Default on
-            // portal types.
-            let route = Route {
-                salt: intent.route.salt,
-                deadline: intent.route.deadline,
-                portal: intent.route.portal,
-                native_amount: intent.route.native_amount,
-                tokens: std::mem::take(&mut intent.route.tokens),
-                calls: std::mem::take(&mut intent.route.calls),
-            };
-            let reward = Reward {
-                deadline: intent.reward.deadline,
-                creator: intent.reward.creator,
-                prover: intent.reward.prover,
-                native_amount: intent.reward.native_amount,
-                tokens: std::mem::take(&mut intent.reward.tokens),
-            };
             Ok((route, reward, route_hash, reward_hash, intent_hash))
         }
     }

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -125,7 +125,7 @@ pub struct FlashFulfill<'info> {
 /// support `Option<NestedAccounts>`, so the pairing is enforced at runtime
 /// (`WriterRequired` if buffer is supplied without writer).
 pub fn flash_fulfill<'info>(
-    ctx: Context<'_, '_, '_, 'info, FlashFulfill<'info>>,
+    mut ctx: Context<'_, '_, '_, 'info, FlashFulfill<'info>>,
     args: FlashFulfillArgs,
 ) -> Result<()> {
     let FlashFulfillArgs { intent } = args;
@@ -136,7 +136,7 @@ pub fn flash_fulfill<'info>(
     );
 
     let should_close = matches!(intent, FlashFulfillIntent::IntentHash(_));
-    let (route, reward) = resolve_intent(&ctx, intent)?;
+    let (route, reward) = resolve_intent(&mut ctx, intent)?;
     let route_hash = route.hash();
     let reward_hash = reward.hash();
     let intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
@@ -420,7 +420,7 @@ fn sweep_leftover_native<'info>(
 }
 
 fn resolve_intent(
-    ctx: &Context<FlashFulfill>,
+    ctx: &mut Context<FlashFulfill>,
     intent: FlashFulfillIntent,
 ) -> Result<(Route, Reward)> {
     match intent {
@@ -429,7 +429,7 @@ fn resolve_intent(
             let intent = ctx
                 .accounts
                 .flash_fulfill_intent
-                .as_ref()
+                .as_mut()
                 .ok_or(FlashFulfillerError::InvalidFlashFulfillIntentAccount)?;
             let writer = ctx
                 .accounts
@@ -458,7 +458,27 @@ fn resolve_intent(
                 FlashFulfillerError::InvalidFlashFulfillIntentAccount
             );
 
-            Ok((intent.route.clone(), intent.reward.clone()))
+            // The buffer is closed at the end of the handler, so move the Vec
+            // payloads out of it instead of cloning the (potentially ~2.5 KB)
+            // Route + Reward. Small Copy fields are read inline; only the Vec
+            // fields go through `mem::take` to avoid requiring Default on
+            // portal types.
+            let route = Route {
+                salt: intent.route.salt,
+                deadline: intent.route.deadline,
+                portal: intent.route.portal,
+                native_amount: intent.route.native_amount,
+                tokens: std::mem::take(&mut intent.route.tokens),
+                calls: std::mem::take(&mut intent.route.calls),
+            };
+            let reward = Reward {
+                deadline: intent.reward.deadline,
+                creator: intent.reward.creator,
+                prover: intent.reward.prover,
+                native_amount: intent.reward.native_amount,
+                tokens: std::mem::take(&mut intent.reward.tokens),
+            };
+            Ok((route, reward))
         }
     }
 }

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -17,7 +17,7 @@ use spl_pod::option::Nullable;
 
 use crate::cpi;
 use crate::events::FlashFulfilled;
-use crate::instructions::FlashFulfillerError;
+use crate::instructions::{close_buffer, FlashFulfillerError};
 use crate::state::{flash_vault_pda, FlashFulfillIntentAccount, FLASH_VAULT_SEED};
 
 struct FlashFulfillAccounts<'a, 'info> {
@@ -236,26 +236,7 @@ pub fn flash_fulfill<'info>(
             ctx.accounts.writer.as_ref().expect(
                 "writer must be Some when intent is IntentHash (validated in resolve_intent)",
             );
-        // Manual replication of Anchor's `Account::close` for an `UncheckedAccount`,
-        // since the buffer is no longer wrapped by `Account<_, T>`. Sequence:
-        //   1. Drain lamports from `buffer` into `writer` (rent refund target).
-        //   2. Zero the 8-byte discriminator so any code path that re-reads the
-        //      account in the same tx cannot match a `FlashFulfillIntentAccount`.
-        //   3. Realloc data to 0 bytes.
-        //   4. Reassign ownership to the system program — completes the close.
-        let dest_starting_lamports = writer.lamports();
-        **writer.lamports.borrow_mut() = dest_starting_lamports
-            .checked_add(buffer.lamports())
-            .ok_or(FlashFulfillerError::BufferLengthOverflow)?;
-        **buffer.lamports.borrow_mut() = 0;
-        {
-            let mut data = buffer.try_borrow_mut_data()?;
-            if data.len() >= 8 {
-                data[..8].fill(0);
-            }
-        }
-        buffer.realloc(0, false)?;
-        buffer.assign(&anchor_lang::system_program::ID);
+        close_buffer(buffer, writer)?;
     }
 
     emit_cpi!(FlashFulfilled {
@@ -332,7 +313,7 @@ fn init_flash_vault_reward_ata<'info>(
         &ctx.accounts.token_2022_program,
     )?;
 
-    associated_token::create_idempotent(CpiContext::new(
+    associated_token::create(CpiContext::new(
         ctx.accounts.associated_token_program.to_account_info(),
         associated_token::Create {
             payer: ctx.accounts.payer.to_account_info(),
@@ -500,7 +481,6 @@ fn resolve_intent(
             // is closed at the end of the handler.
             let intent_account: FlashFulfillIntentAccount =
                 AnchorDeserialize::deserialize(&mut &data[8..])?;
-            drop(data);
 
             // Security boundary: the writer account is the rent-refund target, so we
             // must verify it actually owns this buffer's PDA. The seed binding

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -136,10 +136,7 @@ pub fn flash_fulfill<'info>(
     );
 
     let should_close = matches!(intent, FlashFulfillIntent::IntentHash(_));
-    let (route, reward) = resolve_intent(&mut ctx, intent)?;
-    let route_hash = route.hash();
-    let reward_hash = reward.hash();
-    let intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
+    let (route, reward, route_hash, reward_hash, intent_hash) = resolve_intent(&mut ctx, intent)?;
     let native_fee = reward.native_amount.saturating_sub(route.native_amount);
     let flash_vault = ctx.accounts.flash_vault.key();
     let (_, flash_vault_bump) = flash_vault_pda();
@@ -422,9 +419,14 @@ fn sweep_leftover_native<'info>(
 fn resolve_intent(
     ctx: &mut Context<FlashFulfill>,
     intent: FlashFulfillIntent,
-) -> Result<(Route, Reward)> {
+) -> Result<(Route, Reward, Bytes32, Bytes32, Bytes32)> {
     match intent {
-        FlashFulfillIntent::Intent { route, reward } => Ok((route, reward)),
+        FlashFulfillIntent::Intent { route, reward } => {
+            let route_hash = route.hash();
+            let reward_hash = reward.hash();
+            let intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
+            Ok((route, reward, route_hash, reward_hash, intent_hash))
+        }
         FlashFulfillIntent::IntentHash(intent_hash) => {
             let intent = ctx
                 .accounts
@@ -452,9 +454,11 @@ fn resolve_intent(
             // against the seed `intent_hash` — without this check, `args.intent_hash`
             // and the intent actually fulfilled (recomputed from the buffer downstream)
             // could diverge silently.
+            let route_hash = intent.route.hash();
+            let reward_hash = intent.reward.hash();
+            let computed_intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
             require!(
-                intent_hash
-                    == types::intent_hash(CHAIN_ID, &intent.route.hash(), &intent.reward.hash()),
+                intent_hash == computed_intent_hash,
                 FlashFulfillerError::InvalidFlashFulfillIntentAccount
             );
 
@@ -478,7 +482,7 @@ fn resolve_intent(
                 native_amount: intent.reward.native_amount,
                 tokens: std::mem::take(&mut intent.reward.tokens),
             };
-            Ok((route, reward))
+            Ok((route, reward, route_hash, reward_hash, intent_hash))
         }
     }
 }

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -287,15 +287,16 @@ fn extract_flash_fulfill_accounts<'a, 'info>(
     init_flash_vault_reward_atas(ctx, &reward)?;
 
     let route = VecTokenTransferAccounts::try_from(route_slice)?.into_inner();
-    let claimant = reward
-        .iter()
-        .zip(claimant_atas.iter())
-        .map(|(reward_transfer, claimant_ata)| TokenTransferAccounts {
+    // Pre-size to avoid bump-allocator doubling waste — see `cpi/fulfill.rs:26-33`
+    // for the full rationale (Solana's bump allocator never frees).
+    let mut claimant = Vec::with_capacity(reward_token_count);
+    claimant.extend(reward.iter().zip(claimant_atas.iter()).map(
+        |(reward_transfer, claimant_ata)| TokenTransferAccounts {
             from: reward_transfer.to.to_account_info(),
             to: claimant_ata.to_account_info(),
             mint: reward_transfer.mint.to_account_info(),
-        })
-        .collect();
+        },
+    ));
 
     Ok(FlashFulfillAccounts {
         reward,

--- a/programs/flash-fulfiller/src/instructions/mod.rs
+++ b/programs/flash-fulfiller/src/instructions/mod.rs
@@ -39,11 +39,9 @@ pub fn close_buffer<'info>(
     let dest_starting_lamports = destination.lamports();
     **destination.lamports.borrow_mut() = dest_starting_lamports
         .checked_add(buffer.lamports())
-        .ok_or(FlashFulfillerError::BufferLengthOverflow)?;
+        .expect("lamport sum cannot overflow u64");
     **buffer.lamports.borrow_mut() = 0;
 
-    buffer.realloc(0, false)?;
     buffer.assign(&anchor_lang::system_program::ID);
-
-    Ok(())
+    buffer.realloc(0, false).map_err(Into::into)
 }

--- a/programs/flash-fulfiller/src/instructions/mod.rs
+++ b/programs/flash-fulfiller/src/instructions/mod.rs
@@ -31,3 +31,19 @@ pub enum FlashFulfillerError {
     /// or arithmetic on the prefix length overflows.
     InvalidCallData,
 }
+
+pub fn close_buffer<'info>(
+    buffer: &AccountInfo<'info>,
+    destination: &AccountInfo<'info>,
+) -> Result<()> {
+    let dest_starting_lamports = destination.lamports();
+    **destination.lamports.borrow_mut() = dest_starting_lamports
+        .checked_add(buffer.lamports())
+        .ok_or(FlashFulfillerError::BufferLengthOverflow)?;
+    **buffer.lamports.borrow_mut() = 0;
+
+    buffer.realloc(0, false)?;
+    buffer.assign(&anchor_lang::system_program::ID);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Five low-risk optimizations to `flash_fulfill` that shave an estimated **~80-150K compute units** from the path executed before Portal's `fulfill` CPI. Motivation: production ANY_TO_ANY transactions on Solana have been observed consuming up to 91% of the per-tx 1.4M CU cap, with one observed CU-exhaustion failure inside the Portal `fulfill` CPI on intent `0x5d87ed27110fe3161cffcd46d4a89849def72aa7a7fa423ef4126b71ef5ea0e3`. The flash_fulfiller frame was spending ~790K CU before invoking Portal `fulfill`. None of these changes touch Portal or `eco-svm-std` — the entire diff is confined to `programs/flash-fulfiller/src/instructions/flash_fulfill.rs`.

The optimizations, one per commit (oldest first):

| # | Commit | Optimization | Est. CU saved |
|---|--------|--------------|---------------|
| 1 | `e7dbb73` | Replace `intent.route.clone()` / `intent.reward.clone()` in `resolve_intent` with field-by-field reconstruction — primitives (`Bytes32`, `u64`, `Pubkey`) read by Copy, only `Vec` fields moved via `std::mem::take`. The buffer is closed at handler end, so leaving empty `Vec`s in place is correct. | 50-100K |
| 2 | `a717c68` | Return precomputed `(route_hash, reward_hash, intent_hash)` from `resolve_intent` instead of recomputing them at the caller. The IntentHash arm already computed all three to validate the buffer; the Intent (inline) arm now computes them once before returning. | 10-15K |
| 3 | `a62f583` | Switch the intent buffer from `Account<'info, FlashFulfillIntentAccount>` to `UncheckedAccount<'info>` and validate manually in `resolve_intent` (owner check + length check + discriminator check + PDA re-derivation + intent_hash equality). Skips Anchor's auto-reserialize-on-exit since the buffer is closed at handler end anyway. Manual close replicates `Account::close`: drain lamports → zero discriminator → realloc(0) → assign back to System Program. | 5-20K |
| 4 | `e979029` | Short-circuit `init_flash_vault_reward_ata` when the destination ATA already has data — skips the `associated_token::create_idempotent` CPI overhead (the idempotent op is a no-op on-chain anyway, but the CPI itself costs CU). | 5-15K per skipped token |
| 5 | `1226936` | Pre-size the `claimant` Vec capacity in `extract_flash_fulfill_accounts` via `Vec::with_capacity` + `extend` instead of `.collect()`. Avoids the bump-allocator-doubling anti-pattern explicitly called out in `cpi/fulfill.rs:26-33`. | 2-5K |

### Security notes (commit 3 specifically)

The Anchor `Account` wrapper provided automatic owner + discriminator validation on entry. Replacing it with `UncheckedAccount` means we explicitly enforce those checks in `resolve_intent`:

- **Owner check**: `require!(buffer.owner == &crate::ID, ...)` — rejects accounts not owned by flash_fulfiller. Without this, an attacker could pass a system-owned (or other-program-owned) account whose contents happen to deserialize as `FlashFulfillIntentAccount`.
- **Length check**: `require!(data.len() >= 8, ...)` — guards the discriminator slice from indexing into an empty or undersized account.
- **Discriminator check**: `require!(&data[..8] == FlashFulfillIntentAccount::DISCRIMINATOR, ...)` — rejects accounts of the wrong type, using the Anchor 0.30+ `DISCRIMINATOR` constant.
- **PDA re-derivation** (preserved from before): `require!(buffer.key() == FlashFulfillIntentAccount::pda(&writer.key(), &intent_hash).0, ...)` — the primary anti-squat protection; only the writer who created the buffer can derive its PDA.
- **Intent-hash equality** (preserved from before): the recomputed `intent_hash` must match the seed-supplied one, so streamed buffer chunks can't diverge silently from the seed.

The manual close sequence (drain lamports → zero discriminator → realloc(0) → assign to system program) mirrors Anchor's `Account::close` exactly. Reentering the account in the same tx after close finds a zeroed discriminator and fails the discriminator check.
