### PR TITLE
chore: pin local-prover declare_id to mainnet deployment

### DIFF
--- a/programs/local-prover/src/lib.rs
+++ b/programs/local-prover/src/lib.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use eco_svm_std::prover;
 
-declare_id!("34pNy1Kn6VzTrEK8fg1z24fknE8r1EYncASV7wQh1x6j");
+declare_id!("EcoPZL6PoZ5zHUUpmJLfux1jw126W7jhBB8zrVaFaK1y");
 
 pub mod instructions;
 pub mod state;


### PR DESCRIPTION
## Summary
- Update `declare_id!` in `programs/local-prover/src/lib.rs` to the mainnet program ID `EcoPZL6PoZ5zHUUpmJLfux1jw126W7jhBB8zrVaFaK1y`.
- Pins the program ID so `solana-verify` and Anchor IDL clients resolve the correct address at build time.
- The on-chain program at that address was upgraded with a Docker-verifiable build whose source matches this branch.

## Test Plan
- [ ] `anchor build` succeeds and emits IDL with the mainnet program ID.
- [ ] `solana-verify verify-from-repo` against `EcoPZL6PoZ5zHUUpmJLfux1jw126W7jhBB8zrVaFaK1y` matches this branch.