### PR TITLE
fix(portal): reduce fulfill heap usage when hashing routes

### DIFF
--- a/programs/portal/src/instructions/fulfill.rs
+++ b/programs/portal/src/instructions/fulfill.rs
@@ -1,6 +1,5 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::instruction::{AccountMeta, Instruction};
-use anchor_lang::solana_program::log::sol_log_compute_units;
 use anchor_lang::solana_program::program::invoke_signed;
 use anchor_lang::system_program;
 use anchor_spl::{associated_token, token, token_2022};
@@ -64,52 +63,16 @@ pub fn fulfill_intent<'info>(
         PortalError::RouteExpired
     );
 
-    msg!(
-        "portal.fulfill: start tokens={} calls={} native_amount={} remaining_accounts={}",
-        route.tokens.len(),
-        route.calls.len(),
-        route.native_amount,
-        ctx.remaining_accounts.len()
-    );
     let (token_transfer_accounts, call_accounts) = token_transfer_and_call_accounts(&ctx, &route)?;
-    msg!(
-        "portal.fulfill: split_accounts token_transfer_accounts={} call_accounts={}",
-        route.tokens.len() * VEC_TOKEN_TRANSFER_ACCOUNTS_CHUNK_SIZE,
-        call_accounts.len()
-    );
-    msg!("portal.fulfill: before_fund_executor");
     fund_executor(&ctx, &route, token_transfer_accounts)?;
-    msg!("portal.fulfill: after_fund_executor");
-    msg!("portal.fulfill: before_execute_route_calls");
     let route = execute_route_calls(ctx.accounts.executor.key, route, call_accounts)?;
-    msg!("portal.fulfill: after_execute_route_calls");
 
-    msg!(
-        "portal.fulfill: route_hash_input tokens={} calls={} estimated_route_bytes={}",
-        route.tokens.len(),
-        route.calls.len(),
-        route.estimated_serialized_len()
-    );
-    for (index, call) in route.calls.iter().enumerate() {
-        msg!(
-            "portal.fulfill: route_hash_call call={} data_len={}",
-            index,
-            call.data.len()
-        );
-    }
-    sol_log_compute_units();
-    msg!("portal.fulfill: before_route_hash");
-    let route_hash = route.hash();
-    msg!("portal.fulfill: after_route_hash");
-    sol_log_compute_units();
-    let intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
+    let intent_hash = types::intent_hash(CHAIN_ID, &route.hash(), &reward_hash);
     require!(
         intent_hash == expected_intent_hash,
         PortalError::InvalidIntentHash
     );
-    msg!("portal.fulfill: before_mark_fulfilled");
     mark_fulfilled(&ctx, &intent_hash, &claimant)?;
-    msg!("portal.fulfill: after_mark_fulfilled");
 
     emit!(IntentFulfilled::new(intent_hash, claimant));
 
@@ -168,58 +131,26 @@ fn execute_route_calls(
     let signer_seeds = [EXECUTOR_SEED, &[bump]];
     let mut call_accounts = call_accounts.iter();
 
-    route
-        .calls
-        .iter_mut()
-        .enumerate()
-        .try_for_each(|(index, call)| {
-            msg!(
-                "portal.exec: call={} before_calldata_decode compact_len={}",
-                index,
-                call.data.len()
-            );
-            let calldata = Calldata::try_from_slice(&call.data)?;
-            let target = Pubkey::new_from_array(call.target.into());
-            msg!(
-                "portal.exec: call={} decoded account_count={} data_len={}",
-                index,
-                calldata.account_count,
-                calldata.data.len()
-            );
-            let call_accounts: Vec<_> = call_accounts
-                .by_ref()
-                .take(calldata.account_count as usize)
-                .map(ToAccountInfo::to_account_info)
-                .collect();
-            msg!(
-                "portal.exec: call={} collected_accounts={}",
-                index,
-                call_accounts.len()
-            );
+    route.calls.iter_mut().try_for_each(|call| {
+        let calldata = Calldata::try_from_slice(&call.data)?;
+        let call_accounts: Vec<_> = call_accounts
+            .by_ref()
+            .take(calldata.account_count as usize)
+            .map(ToAccountInfo::to_account_info)
+            .collect();
 
-            msg!("portal.exec: call={} before_invoke", index);
-            execute_route_call(
-                executor,
-                target,
-                &calldata.data,
-                &call_accounts,
-                &signer_seeds,
-            )?;
-            msg!("portal.exec: call={} after_invoke", index);
+        execute_route_call(
+            executor,
+            Pubkey::new_from_array(call.target.into()),
+            &calldata.data,
+            &call_accounts,
+            &signer_seeds,
+        )?;
 
-            msg!("portal.exec: call={} before_rebuild_full_calldata", index);
-            let calldata_with_accounts = CalldataWithAccounts::new(calldata, call_accounts)?;
-            msg!("portal.exec: call={} after_rebuild_full_calldata", index);
-            msg!("portal.exec: call={} before_serialize_full_calldata", index);
-            call.data = calldata_with_accounts.try_to_vec()?;
-            msg!(
-                "portal.exec: call={} after_serialize_full_calldata len={}",
-                index,
-                call.data.len()
-            );
+        call.data = CalldataWithAccounts::new(calldata, call_accounts)?.try_to_vec()?;
 
-            Result::Ok(())
-        })?;
+        Result::Ok(())
+    })?;
 
     Ok(route)
 }

--- a/programs/portal/src/instructions/fulfill.rs
+++ b/programs/portal/src/instructions/fulfill.rs
@@ -63,16 +63,37 @@ pub fn fulfill_intent<'info>(
         PortalError::RouteExpired
     );
 
+    msg!(
+        "portal.fulfill: start tokens={} calls={} native_amount={} remaining_accounts={}",
+        route.tokens.len(),
+        route.calls.len(),
+        route.native_amount,
+        ctx.remaining_accounts.len()
+    );
     let (token_transfer_accounts, call_accounts) = token_transfer_and_call_accounts(&ctx, &route)?;
+    msg!(
+        "portal.fulfill: split_accounts token_transfer_accounts={} call_accounts={}",
+        route.tokens.len() * VEC_TOKEN_TRANSFER_ACCOUNTS_CHUNK_SIZE,
+        call_accounts.len()
+    );
+    msg!("portal.fulfill: before_fund_executor");
     fund_executor(&ctx, &route, token_transfer_accounts)?;
+    msg!("portal.fulfill: after_fund_executor");
+    msg!("portal.fulfill: before_execute_route_calls");
     let route = execute_route_calls(ctx.accounts.executor.key, route, call_accounts)?;
+    msg!("portal.fulfill: after_execute_route_calls");
 
-    let intent_hash = types::intent_hash(CHAIN_ID, &route.hash(), &reward_hash);
+    msg!("portal.fulfill: before_route_hash");
+    let route_hash = route.hash();
+    msg!("portal.fulfill: after_route_hash");
+    let intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
     require!(
         intent_hash == expected_intent_hash,
         PortalError::InvalidIntentHash
     );
+    msg!("portal.fulfill: before_mark_fulfilled");
     mark_fulfilled(&ctx, &intent_hash, &claimant)?;
+    msg!("portal.fulfill: after_mark_fulfilled");
 
     emit!(IntentFulfilled::new(intent_hash, claimant));
 
@@ -131,26 +152,58 @@ fn execute_route_calls(
     let signer_seeds = [EXECUTOR_SEED, &[bump]];
     let mut call_accounts = call_accounts.iter();
 
-    route.calls.iter_mut().try_for_each(|call| {
-        let calldata = Calldata::try_from_slice(&call.data)?;
-        let call_accounts: Vec<_> = call_accounts
-            .by_ref()
-            .take(calldata.account_count as usize)
-            .map(ToAccountInfo::to_account_info)
-            .collect();
+    route
+        .calls
+        .iter_mut()
+        .enumerate()
+        .try_for_each(|(index, call)| {
+            msg!(
+                "portal.exec: call={} before_calldata_decode compact_len={}",
+                index,
+                call.data.len()
+            );
+            let calldata = Calldata::try_from_slice(&call.data)?;
+            let target = Pubkey::new_from_array(call.target.into());
+            msg!(
+                "portal.exec: call={} decoded account_count={} data_len={}",
+                index,
+                calldata.account_count,
+                calldata.data.len()
+            );
+            let call_accounts: Vec<_> = call_accounts
+                .by_ref()
+                .take(calldata.account_count as usize)
+                .map(ToAccountInfo::to_account_info)
+                .collect();
+            msg!(
+                "portal.exec: call={} collected_accounts={}",
+                index,
+                call_accounts.len()
+            );
 
-        execute_route_call(
-            executor,
-            Pubkey::new_from_array(call.target.into()),
-            &calldata.data,
-            &call_accounts,
-            &signer_seeds,
-        )?;
+            msg!("portal.exec: call={} before_invoke", index);
+            execute_route_call(
+                executor,
+                target,
+                &calldata.data,
+                &call_accounts,
+                &signer_seeds,
+            )?;
+            msg!("portal.exec: call={} after_invoke", index);
 
-        call.data = CalldataWithAccounts::new(calldata, call_accounts)?.try_to_vec()?;
+            msg!("portal.exec: call={} before_rebuild_full_calldata", index);
+            let calldata_with_accounts = CalldataWithAccounts::new(calldata, call_accounts)?;
+            msg!("portal.exec: call={} after_rebuild_full_calldata", index);
+            msg!("portal.exec: call={} before_serialize_full_calldata", index);
+            call.data = calldata_with_accounts.try_to_vec()?;
+            msg!(
+                "portal.exec: call={} after_serialize_full_calldata len={}",
+                index,
+                call.data.len()
+            );
 
-        Result::Ok(())
-    })?;
+            Result::Ok(())
+        })?;
 
     Ok(route)
 }

--- a/programs/portal/src/instructions/fulfill.rs
+++ b/programs/portal/src/instructions/fulfill.rs
@@ -1,5 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::instruction::{AccountMeta, Instruction};
+use anchor_lang::solana_program::log::sol_log_compute_units;
 use anchor_lang::solana_program::program::invoke_signed;
 use anchor_lang::system_program;
 use anchor_spl::{associated_token, token, token_2022};
@@ -83,9 +84,24 @@ pub fn fulfill_intent<'info>(
     let route = execute_route_calls(ctx.accounts.executor.key, route, call_accounts)?;
     msg!("portal.fulfill: after_execute_route_calls");
 
+    msg!(
+        "portal.fulfill: route_hash_input tokens={} calls={} estimated_route_bytes={}",
+        route.tokens.len(),
+        route.calls.len(),
+        route.estimated_serialized_len()
+    );
+    for (index, call) in route.calls.iter().enumerate() {
+        msg!(
+            "portal.fulfill: route_hash_call call={} data_len={}",
+            index,
+            call.data.len()
+        );
+    }
+    sol_log_compute_units();
     msg!("portal.fulfill: before_route_hash");
     let route_hash = route.hash();
     msg!("portal.fulfill: after_route_hash");
+    sol_log_compute_units();
     let intent_hash = types::intent_hash(CHAIN_ID, &route_hash, &reward_hash);
     require!(
         intent_hash == expected_intent_hash,

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -238,6 +238,21 @@ impl Route {
         hash.into()
     }
 
+    pub fn estimated_serialized_len(&self) -> usize {
+        32 // salt
+            + 8 // deadline
+            + 32 // portal
+            + 8 // native_amount
+            + 4 // tokens vec length
+            + self.tokens.len() * (32 + 8)
+            + 4 // calls vec length
+            + self
+                .calls
+                .iter()
+                .map(|call| 32 + 4 + call.data.len())
+                .sum::<usize>()
+    }
+
     pub fn token_amounts(&self) -> Result<BTreeMap<Pubkey, u64>> {
         token_amounts(&self.tokens)
     }
@@ -759,6 +774,41 @@ mod tests {
         };
 
         goldie::assert_json!(route.hash().as_ref());
+    }
+
+    #[test]
+    fn route_estimated_serialized_len_matches_borsh() {
+        let route = Route {
+            deadline: 1700000000,
+            salt: [1u8; 32].into(),
+            portal: [2u8; 32].into(),
+            native_amount: 10,
+            tokens: vec![
+                TokenAmount {
+                    token: Pubkey::new_from_array([3u8; 32]),
+                    amount: 100,
+                },
+                TokenAmount {
+                    token: Pubkey::new_from_array([4u8; 32]),
+                    amount: 200,
+                },
+            ],
+            calls: vec![
+                Call {
+                    target: [5u8; 32].into(),
+                    data: vec![1, 2, 3],
+                },
+                Call {
+                    target: [6u8; 32].into(),
+                    data: vec![4, 5, 6, 7, 8],
+                },
+            ],
+        };
+
+        assert_eq!(
+            route.estimated_serialized_len(),
+            route.try_to_vec().unwrap().len()
+        );
     }
 
     #[test]

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -256,21 +256,6 @@ impl Route {
         }
     }
 
-    pub fn estimated_serialized_len(&self) -> usize {
-        32 // salt
-            + 8 // deadline
-            + 32 // portal
-            + 8 // native_amount
-            + 4 // tokens vec length
-            + self.tokens.len() * (32 + 8)
-            + 4 // calls vec length
-            + self
-                .calls
-                .iter()
-                .map(|call| 32 + 4 + call.data.len())
-                .sum::<usize>()
-    }
-
     pub fn token_amounts(&self) -> Result<BTreeMap<Pubkey, u64>> {
         token_amounts(&self.tokens)
     }
@@ -852,41 +837,6 @@ mod tests {
         hasher.finalize(&mut hash);
 
         assert_eq!(route.hash_streaming(), Bytes32::from(hash));
-    }
-
-    #[test]
-    fn route_estimated_serialized_len_matches_borsh() {
-        let route = Route {
-            deadline: 1700000000,
-            salt: [1u8; 32].into(),
-            portal: [2u8; 32].into(),
-            native_amount: 10,
-            tokens: vec![
-                TokenAmount {
-                    token: Pubkey::new_from_array([3u8; 32]),
-                    amount: 100,
-                },
-                TokenAmount {
-                    token: Pubkey::new_from_array([4u8; 32]),
-                    amount: 200,
-                },
-            ],
-            calls: vec![
-                Call {
-                    target: [5u8; 32].into(),
-                    data: vec![1, 2, 3],
-                },
-                Call {
-                    target: [6u8; 32].into(),
-                    data: vec![4, 5, 6, 7, 8],
-                },
-            ],
-        };
-
-        assert_eq!(
-            route.estimated_serialized_len(),
-            route.try_to_vec().unwrap().len()
-        );
     }
 
     #[test]

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -805,32 +805,63 @@ mod tests {
 
     #[test]
     fn route_streaming_hash_matches_borsh_serialized_hash() {
-        let route = Route {
-            deadline: 1700000000,
-            salt: [1u8; 32].into(),
-            portal: [2u8; 32].into(),
-            native_amount: 10,
-            tokens: vec![
-                TokenAmount {
-                    token: Pubkey::new_from_array([3u8; 32]),
-                    amount: 100,
-                },
-                TokenAmount {
-                    token: Pubkey::new_from_array([4u8; 32]),
-                    amount: 200,
-                },
-            ],
-            calls: vec![
-                Call {
-                    target: [5u8; 32].into(),
-                    data: vec![1, 2, 3],
-                },
-                Call {
-                    target: [6u8; 32].into(),
-                    data: vec![4, 5, 6, 7, 8],
-                },
-            ],
-        };
+        let routes = [
+            Route {
+                deadline: 1700000000,
+                salt: [1u8; 32].into(),
+                portal: [2u8; 32].into(),
+                native_amount: 10,
+                tokens: vec![
+                    TokenAmount {
+                        token: Pubkey::new_from_array([3u8; 32]),
+                        amount: 100,
+                    },
+                    TokenAmount {
+                        token: Pubkey::new_from_array([4u8; 32]),
+                        amount: 200,
+                    },
+                ],
+                calls: vec![
+                    Call {
+                        target: [5u8; 32].into(),
+                        data: vec![1, 2, 3],
+                    },
+                    Call {
+                        target: [6u8; 32].into(),
+                        data: vec![4, 5, 6, 7, 8],
+                    },
+                ],
+            },
+            Route {
+                deadline: 0,
+                salt: [7u8; 32].into(),
+                portal: [8u8; 32].into(),
+                native_amount: 0,
+                tokens: vec![],
+                calls: vec![],
+            },
+            Route {
+                deadline: 0,
+                salt: [9u8; 32].into(),
+                portal: [10u8; 32].into(),
+                native_amount: 0,
+                tokens: vec![TokenAmount {
+                    token: Pubkey::new_from_array([11u8; 32]),
+                    amount: 0,
+                }],
+                calls: vec![Call {
+                    target: [12u8; 32].into(),
+                    data: vec![],
+                }],
+            },
+        ];
+
+        for route in routes {
+            assert_route_streaming_hash_matches_borsh(&route);
+        }
+    }
+
+    fn assert_route_streaming_hash_matches_borsh(route: &Route) {
         let mut hasher = Keccak::v256();
         let mut hash = [0u8; 32];
         hasher.update(&route.try_to_vec().unwrap());

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -228,14 +228,32 @@ pub struct Route {
 
 impl Route {
     pub fn hash(&self) -> Bytes32 {
-        let encoded = self.try_to_vec().expect("Failed to serialize Route");
+        self.hash_streaming()
+    }
+
+    fn hash_streaming(&self) -> Bytes32 {
         let mut hasher = Keccak::v256();
         let mut hash = [0u8; 32];
 
-        hasher.update(&encoded);
+        self.update_hash(&mut hasher);
         hasher.finalize(&mut hash);
 
         hash.into()
+    }
+
+    fn update_hash(&self, hasher: &mut Keccak) {
+        hasher.update(self.salt.as_ref());
+        update_hash_u64(hasher, self.deadline);
+        hasher.update(self.portal.as_ref());
+        update_hash_u64(hasher, self.native_amount);
+        update_hash_len(hasher, self.tokens.len());
+        for token in &self.tokens {
+            token.update_hash(hasher);
+        }
+        update_hash_len(hasher, self.calls.len());
+        for call in &self.calls {
+            call.update_hash(hasher);
+        }
     }
 
     pub fn estimated_serialized_len(&self) -> usize {
@@ -303,10 +321,34 @@ pub struct TokenAmount {
     pub amount: u64,
 }
 
+impl TokenAmount {
+    fn update_hash(&self, hasher: &mut Keccak) {
+        hasher.update(self.token.as_ref());
+        update_hash_u64(hasher, self.amount);
+    }
+}
+
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
 pub struct Call {
     pub target: Bytes32,
     pub data: Vec<u8>,
+}
+
+impl Call {
+    fn update_hash(&self, hasher: &mut Keccak) {
+        hasher.update(self.target.as_ref());
+        update_hash_len(hasher, self.data.len());
+        hasher.update(&self.data);
+    }
+}
+
+fn update_hash_len(hasher: &mut Keccak, len: usize) {
+    let len = u32::try_from(len).expect("Borsh vec length exceeds u32");
+    hasher.update(&len.to_le_bytes());
+}
+
+fn update_hash_u64(hasher: &mut Keccak, value: u64) {
+    hasher.update(&value.to_le_bytes());
 }
 
 #[cfg(test)]
@@ -774,6 +816,42 @@ mod tests {
         };
 
         goldie::assert_json!(route.hash().as_ref());
+    }
+
+    #[test]
+    fn route_streaming_hash_matches_borsh_serialized_hash() {
+        let route = Route {
+            deadline: 1700000000,
+            salt: [1u8; 32].into(),
+            portal: [2u8; 32].into(),
+            native_amount: 10,
+            tokens: vec![
+                TokenAmount {
+                    token: Pubkey::new_from_array([3u8; 32]),
+                    amount: 100,
+                },
+                TokenAmount {
+                    token: Pubkey::new_from_array([4u8; 32]),
+                    amount: 200,
+                },
+            ],
+            calls: vec![
+                Call {
+                    target: [5u8; 32].into(),
+                    data: vec![1, 2, 3],
+                },
+                Call {
+                    target: [6u8; 32].into(),
+                    data: vec![4, 5, 6, 7, 8],
+                },
+            ],
+        };
+        let mut hasher = Keccak::v256();
+        let mut hash = [0u8; 32];
+        hasher.update(&route.try_to_vec().unwrap());
+        hasher.finalize(&mut hash);
+
+        assert_eq!(route.hash_streaming(), Bytes32::from(hash));
     }
 
     #[test]

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -228,10 +228,6 @@ pub struct Route {
 
 impl Route {
     pub fn hash(&self) -> Bytes32 {
-        self.hash_streaming()
-    }
-
-    fn hash_streaming(&self) -> Bytes32 {
         let mut hasher = Keccak::v256();
         let mut hash = [0u8; 32];
 
@@ -804,7 +800,7 @@ mod tests {
     }
 
     #[test]
-    fn route_streaming_hash_matches_borsh_serialized_hash() {
+    fn route_hash_matches_borsh_serialized_hash() {
         let routes = [
             Route {
                 deadline: 1700000000,
@@ -857,17 +853,17 @@ mod tests {
         ];
 
         for route in routes {
-            assert_route_streaming_hash_matches_borsh(&route);
+            assert_route_hash_matches_borsh(&route);
         }
     }
 
-    fn assert_route_streaming_hash_matches_borsh(route: &Route) {
+    fn assert_route_hash_matches_borsh(route: &Route) {
         let mut hasher = Keccak::v256();
         let mut hash = [0u8; 32];
         hasher.update(&route.try_to_vec().unwrap());
         hasher.finalize(&mut hash);
 
-        assert_eq!(route.hash_streaming(), Bytes32::from(hash));
+        assert_eq!(route.hash(), Bytes32::from(hash));
     }
 
     #[test]


### PR DESCRIPTION
## Context

The Portal stores compact calldata in `FulfillArgs.route` because Solana instruction data is limited. During `fulfill`, the program:

1. funds the executor from the solver,
2. executes each compact route call with the provided remaining accounts,
3. rebuilds each call into full `CallDataWithAccounts`, and
4. recomputes the route hash so it can verify the expected intent hash before marking fulfillment.

For large Jupiter routes, step 3 can rebuild a route with several KB of call data/account metadata. The route is already resident in memory at that point.

Before this PR, `Route::hash()` then called `try_to_vec()` on the rebuilt route. That creates a second full serialized copy of the route just to feed Keccak. On SVM, that extra allocation can exceed the program heap even when compute is still available.

## Root Cause

Debug logs on the failing path showed:

- Jupiter completed successfully.
- Portal rebuilt all route calls successfully.
- The rebuilt route was approximately `2938` serialized bytes.
- There were still about `645k` compute units remaining.
- The program failed immediately after `before_route_hash` with `memory allocation failed, out of memory`.

So this was not a Jupiter failure and not compute exhaustion. The failure was the heap allocation inside route hashing.

## Change

`Route::hash()` now streams the same Borsh-equivalent bytes directly into Keccak instead of serializing the entire route into a temporary `Vec`.

The streaming order mirrors the existing `Route` serialization layout:

- `salt`
- `deadline` as little-endian `u64`
- `portal`
- `native_amount` as little-endian `u64`
- `tokens` length as little-endian `u32`
- each token pubkey and amount
- `calls` length as little-endian `u32`
- each call target, data length, and data bytes

This reduces peak heap usage at the exact failing point while preserving the route hash format.

## Compatibility

This PR does not change:

- the `Route` struct layout,
- the intent hash formula,
- the route encoding format,
- instruction accounts,
- CPI behavior,
- reward hashing.

Only the implementation of `Route::hash()` changes from “serialize then hash” to “stream fields into the hasher”.

## Tests

Added regression coverage that compares the new streaming route hash against the old Borsh-serialized hash output.

The test covers:

- a normal route with tokens and calls,
- empty `tokens` and empty `calls`,
- zero `deadline` / `native_amount`,
- empty call `data`.

This directly checks the invariant this PR relies on:

```text
hash(streamed Borsh-equivalent bytes) == hash(route.try_to_vec())
```

## Validation

Ran:

- `cargo test -p portal`
- `cargo check --workspace`

The change was also validated against a large Jupiter-shaped route on the debug deployment. The same class of route that previously failed at route hashing fulfilled successfully after this change.

## Notes

Temporary trace logs used during investigation were removed from the final tree. The remaining diff is the streaming hash implementation plus compatibility tests.