### PR TITLE
fix(portal): eliminate heap allocations in Route and Reward hash

### DIFF
--- a/programs/portal/src/keccak_writer.rs
+++ b/programs/portal/src/keccak_writer.rs
@@ -1,0 +1,23 @@
+use std::io;
+
+use tiny_keccak::{Hasher, Keccak};
+
+pub struct KeccakWriter<'a>(&'a mut Keccak);
+
+impl<'a> KeccakWriter<'a> {
+    pub fn new(hasher: &'a mut Keccak) -> Self {
+        Self(hasher)
+    }
+}
+
+impl io::Write for KeccakWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.update(buf);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/programs/portal/src/lib.rs
+++ b/programs/portal/src/lib.rs
@@ -50,3 +50,43 @@ pub mod portal {
         prove_intent(ctx, args)
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_alloc {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+
+    pub(crate) struct TrackingAllocator;
+
+    thread_local! {
+        static ALLOC_COUNT: Cell<Option<usize>> = const { Cell::new(None) };
+    }
+
+    /// Begin counting heap allocations on this thread. Resets any prior count.
+    pub(crate) fn start_counting() {
+        ALLOC_COUNT.with(|c| c.set(Some(0)));
+    }
+
+    /// Stop counting and return the number of allocations since `start_counting`.
+    pub(crate) fn stop_counting() -> usize {
+        ALLOC_COUNT.with(|c| c.take()).unwrap_or(0)
+    }
+
+    unsafe impl GlobalAlloc for TrackingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            ALLOC_COUNT.with(|c| {
+                if let Some(n) = c.get() {
+                    c.set(Some(n + 1));
+                }
+            });
+            unsafe { System.alloc(layout) }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+}

--- a/programs/portal/src/lib.rs
+++ b/programs/portal/src/lib.rs
@@ -4,6 +4,7 @@ declare_id!("Ecoo5HDM2XCBy7QzkhDGrAmnRcWw7emU6xGr7CcCmooo");
 
 pub mod events;
 pub mod instructions;
+mod keccak_writer;
 pub mod state;
 pub mod types;
 

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use tiny_keccak::{Hasher, Keccak};
 
 use crate::instructions::PortalError;
+use crate::keccak_writer::KeccakWriter;
 
 pub const VEC_TOKEN_TRANSFER_ACCOUNTS_CHUNK_SIZE: usize = 3;
 
@@ -231,25 +232,11 @@ impl Route {
         let mut hasher = Keccak::v256();
         let mut hash = [0u8; 32];
 
-        self.update_hash(&mut hasher);
+        self.serialize(&mut KeccakWriter::new(&mut hasher))
+            .expect("Route borsh serialization is infallible");
         hasher.finalize(&mut hash);
 
         hash.into()
-    }
-
-    fn update_hash(&self, hasher: &mut Keccak) {
-        hasher.update(self.salt.as_ref());
-        update_hash_u64(hasher, self.deadline);
-        hasher.update(self.portal.as_ref());
-        update_hash_u64(hasher, self.native_amount);
-        update_hash_len(hasher, self.tokens.len());
-        for token in &self.tokens {
-            token.update_hash(hasher);
-        }
-        update_hash_len(hasher, self.calls.len());
-        for call in &self.calls {
-            call.update_hash(hasher);
-        }
     }
 
     pub fn token_amounts(&self) -> Result<BTreeMap<Pubkey, u64>> {
@@ -268,11 +255,11 @@ pub struct Reward {
 
 impl Reward {
     pub fn hash(&self) -> Bytes32 {
-        let encoded = self.try_to_vec().expect("Failed to serialize Reward");
         let mut hasher = Keccak::v256();
         let mut hash = [0u8; 32];
 
-        hasher.update(&encoded);
+        self.serialize(&mut KeccakWriter::new(&mut hasher))
+            .expect("Reward borsh serialization is infallible");
         hasher.finalize(&mut hash);
 
         hash.into()
@@ -302,34 +289,10 @@ pub struct TokenAmount {
     pub amount: u64,
 }
 
-impl TokenAmount {
-    fn update_hash(&self, hasher: &mut Keccak) {
-        hasher.update(self.token.as_ref());
-        update_hash_u64(hasher, self.amount);
-    }
-}
-
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
 pub struct Call {
     pub target: Bytes32,
     pub data: Vec<u8>,
-}
-
-impl Call {
-    fn update_hash(&self, hasher: &mut Keccak) {
-        hasher.update(self.target.as_ref());
-        update_hash_len(hasher, self.data.len());
-        hasher.update(&self.data);
-    }
-}
-
-fn update_hash_len(hasher: &mut Keccak, len: usize) {
-    let len = u32::try_from(len).expect("Borsh vec length exceeds u32");
-    hasher.update(&len.to_le_bytes());
-}
-
-fn update_hash_u64(hasher: &mut Keccak, value: u64) {
-    hasher.update(&value.to_le_bytes());
 }
 
 #[cfg(test)]

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -298,6 +298,7 @@ pub struct Call {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_alloc;
 
     #[test]
     fn intent_hash_deterministic() {
@@ -905,5 +906,45 @@ mod tests {
 
         let result = CalldataWithAccounts::new(calldata, accounts);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn route_hash_no_heap_allocation() {
+        let route = Route {
+            deadline: 1700000000,
+            salt: [1u8; 32].into(),
+            portal: [2u8; 32].into(),
+            native_amount: 10,
+            tokens: vec![TokenAmount {
+                token: Pubkey::new_from_array([3u8; 32]),
+                amount: 100,
+            }],
+            calls: vec![Call {
+                target: [4u8; 32].into(),
+                data: vec![1, 2, 3],
+            }],
+        };
+        let _ = route.hash(); // warm up any lazy init before counting
+        test_alloc::start_counting();
+        let _ = route.hash();
+        assert_eq!(test_alloc::stop_counting(), 0);
+    }
+
+    #[test]
+    fn reward_hash_no_heap_allocation() {
+        let reward = Reward {
+            deadline: 1700000000,
+            creator: Pubkey::new_from_array([1u8; 32]),
+            prover: Pubkey::new_from_array([2u8; 32]),
+            native_amount: 500,
+            tokens: vec![TokenAmount {
+                token: Pubkey::new_from_array([3u8; 32]),
+                amount: 100,
+            }],
+        };
+        let _ = reward.hash(); // warm up any lazy init before counting
+        test_alloc::start_counting();
+        let _ = reward.hash();
+        assert_eq!(test_alloc::stop_counting(), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `KeccakWriter` in `programs/portal/src/keccak_writer.rs` — a thin `io::Write` adapter over `tiny_keccak::Keccak` that forwards each `write` call to `hasher.update`
- Replaces `Reward::hash()`'s `try_to_vec()` + `hasher.update(&encoded)` with `BorshSerialize::serialize` streaming directly into `KeccakWriter` — zero heap allocation
- Replaces `Route::hash()`'s hand-rolled `update_hash` helpers (added in #60) with the same `KeccakWriter` approach, removing `update_hash`, `update_hash_len`, `update_hash_u64`, and the per-type `update_hash` impls on `TokenAmount` and `Call`

Both `hash()` methods now have an identical shape and allocate nothing during hashing. The existing `intent_hash_deterministic` goldie snapshot and `route_hash_matches_borsh_serialized_hash` test confirm the output is unchanged.

## Test plan

- [ ] `cargo test --package portal` — all 24 tests pass, including goldie snapshots for `route_hash_deterministic` and `intent_hash_deterministic`
- [ ] Confirm no new goldie snapshots needed (hashes are identical — borsh encoding unchanged)