### PR TITLE
fix(audit): address v1.0.2 audit findings 1-3

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -9,7 +9,7 @@ skip-lint = false
 dummy-ism = "4GHxwWyKB9exhKG4fdyU2hfLgfFzhHp2WcsSKc2uNR1k"
 flash-fulfiller = "EcoFvY9tDz6kaxAQxNHga68sQm535DskDBCgKm3tziaT"
 hyper-prover = "EcooFDTfKVVo5qZcpNoDngMmVXqrG6FQT1D5LDjZEGeR"
-local-prover = "34pNy1Kn6VzTrEK8fg1z24fknE8r1EYncASV7wQh1x6j"
+local-prover = "EcoPZL6PoZ5zHUUpmJLfux1jw126W7jhBB8zrVaFaK1y"
 portal = "Ecoo5HDM2XCBy7QzkhDGrAmnRcWw7emU6xGr7CcCmooo"
 proof-helper = "EcorrHQ6t8eCJJjGP9db3ZU7Z92efpnqNh24SN9EUjKX"
 
@@ -17,14 +17,14 @@ proof-helper = "EcorrHQ6t8eCJJjGP9db3ZU7Z92efpnqNh24SN9EUjKX"
 flash-fulfiller = "EcoFvY9tDz6kaxAQxNHga68sQm535DskDBCgKm3tziaT"
 hyper-prover = "EcooFDTfKVVo5qZcpNoDngMmVXqrG6FQT1D5LDjZEGeR"
 portal = "Ecoo5HDM2XCBy7QzkhDGrAmnRcWw7emU6xGr7CcCmooo"
-local-prover = "34pNy1Kn6VzTrEK8fg1z24fknE8r1EYncASV7wQh1x6j"
+local-prover = "EcoPZL6PoZ5zHUUpmJLfux1jw126W7jhBB8zrVaFaK1y"
 proof-helper = "EcorrHQ6t8eCJJjGP9db3ZU7Z92efpnqNh24SN9EUjKX"
 
 [programs.mainnet]
 flash-fulfiller = "EcoFvY9tDz6kaxAQxNHga68sQm535DskDBCgKm3tziaT"
 hyper-prover = "EcooFDTfKVVo5qZcpNoDngMmVXqrG6FQT1D5LDjZEGeR"
 portal = "Ecoo5HDM2XCBy7QzkhDGrAmnRcWw7emU6xGr7CcCmooo"
-local-prover = "34pNy1Kn6VzTrEK8fg1z24fknE8r1EYncASV7wQh1x6j"
+local-prover = "EcoPZL6PoZ5zHUUpmJLfux1jw126W7jhBB8zrVaFaK1y"
 proof-helper = "EcorrHQ6t8eCJJjGP9db3ZU7Z92efpnqNh24SN9EUjKX"
 
 [registry]

--- a/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
+++ b/programs/flash-fulfiller/src/instructions/flash_fulfill.rs
@@ -31,7 +31,11 @@ struct FlashFulfillAccounts<'a, 'info> {
 /// referencing a buffer previously written via `set_flash_fulfill_intent`.
 #[derive(AnchorSerialize, AnchorDeserialize)]
 pub enum FlashFulfillIntent {
-    /// Read `(route, reward)` from the buffered `FlashFulfillIntentAccount` for this intent hash.
+    /// Read `(route, reward)` from the buffered `FlashFulfillIntentAccount` for
+    /// this intent hash. Any caller may consume a committed buffer — see
+    /// [`FlashFulfillIntentAccount`] for the open-consumption note. The
+    /// buffer's rent is refunded to the original `writer` regardless of who
+    /// invokes `flash_fulfill`.
     IntentHash(Bytes32),
     /// Inline `(route, reward)` pair; no buffer account is required.
     Intent { route: Route, reward: Reward },

--- a/programs/flash-fulfiller/src/instructions/set_flash_fulfill_intent.rs
+++ b/programs/flash-fulfiller/src/instructions/set_flash_fulfill_intent.rs
@@ -28,6 +28,13 @@ pub struct SetFlashFulfillIntent<'info> {
 
 /// Creates the `FlashFulfillIntentAccount` buffer at the PDA for the supplied `(route, reward)`.
 ///
+/// **Open consumption**: once committed, any caller may invoke `flash_fulfill`
+/// against this buffer and direct the reward spread to their own claimant.
+/// The writer recovers only the buffer's rent. To guarantee capture of the
+/// spread, bundle the final `append_flash_fulfill_intent_chunk` and
+/// `flash_fulfill` in a single transaction where the combined account list
+/// fits within 1232 bytes.
+///
 /// Caller's transaction must prepend
 /// `ComputeBudgetInstruction::request_heap_frame(256 * 1024)` — see the
 /// crate-level docs (applies to every instruction in this program).

--- a/programs/flash-fulfiller/src/state.rs
+++ b/programs/flash-fulfiller/src/state.rs
@@ -15,6 +15,15 @@ pub fn flash_vault_pda() -> (Pubkey, u8) {
 
 /// Stored `(route, reward)` pair that lets `flash_fulfill` be invoked by
 /// intent hash alone, avoiding re-sending the full payload.
+///
+/// **Open consumption**: the PDA is seeded by `(writer, intent_hash)` to
+/// prevent squatting on *write* (only the writer can extend or close their
+/// buffer), but `flash_fulfill` imposes no signer check on the caller — any
+/// third party may consume a committed buffer and direct the spread to their
+/// own claimant. The writer receives only the buffer's rent refund. Writers
+/// who want to capture the spread should bundle the final
+/// `append_flash_fulfill_intent_chunk` with their own `flash_fulfill` in a
+/// single transaction where the combined account list fits in 1232 bytes.
 #[account]
 pub struct FlashFulfillIntentAccount {
     /// Route committed by the buffered intent.

--- a/programs/portal/src/types.rs
+++ b/programs/portal/src/types.rs
@@ -76,22 +76,7 @@ impl<'info> TokenTransferAccounts<'info> {
         authority: &AccountInfo<'info>,
         amount: u64,
     ) -> Result<()> {
-        match amount {
-            0 => Ok(()),
-            amount => transfer_checked(
-                CpiContext::new(
-                    token_program.to_account_info(),
-                    anchor_spl::token_interface::TransferChecked {
-                        from: self.from.to_account_info(),
-                        to: self.to.to_account_info(),
-                        mint: self.mint.to_account_info(),
-                        authority: authority.to_account_info(),
-                    },
-                ),
-                amount,
-                self.mint_data()?.decimals,
-            ),
-        }
+        self.transfer_with_signer(token_program, authority, &[], amount)
     }
 
     pub fn transfer_with_signer(


### PR DESCRIPTION
## Summary

- **Finding 1** — Sync `Anchor.toml` `local-prover` program ID to match `declare_id!` in `programs/local-prover/src/lib.rs`. The old ID (`34pNy1...`) was stale in all three network sections (localnet, devnet, mainnet); any tooling or deployment script reading `Anchor.toml` would have used the wrong on-chain address.
- **Finding 2** — Document open-consumption semantics on `FlashFulfillIntentAccount`, `FlashFulfillIntent::IntentHash`, and `set_flash_fulfill_intent`. The buffer PDA is writer-keyed to prevent squatting on *write*, but `flash_fulfill` imposes no signer check on the *caller* — any third party can consume a committed buffer and direct the reward spread to their own claimant. The writer recovers only the buffer's rent refund.
- **Finding 3** — Eliminate duplicated SPL transfer logic by delegating `transfer()` to `transfer_with_signer()` with empty signer seeds. `CpiContext::new_with_signer(..., &[])` is equivalent to `CpiContext::new(...)`, so behavior is unchanged.

## Test plan

- [ ] `anchor build` succeeds with the updated `Anchor.toml` IDs
- [ ] `cargo test --no-fail-fast` passes (no behavioral change in findings 2–3)
- [ ] Confirm `local-prover` program ID in `Anchor.toml` matches `declare_id!` in `programs/local-prover/src/lib.rs`