### PR TITLE
fix(release): add semantic PR title guard

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,6 +17,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,22 @@
+name: Semantic PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds a source-neutral release-trigger commit so semantic-release can publish the immutable SVM program ID release.
- Adds a PR title lint workflow using `amannn/action-semantic-pull-request@v6` so future squash merge commits follow Conventional Commits.

## Root Cause

PR #63 had conventional branch commits, but the PR title was `Set immutable SVM mainnet program IDs`. The squash merge commit used that PR title, so semantic-release saw a non-conventional commit on `main` and skipped release creation. The manually-created `v1.0.4` tag then made later release workflow runs treat `v1.0.4` as already consumed.

## Release Notes

The stale `v1.0.4` tag was deleted locally and from origin. After this PR merges, rerun the manual Release workflow on `main`; semantic-release should recreate `v1.0.4`, build the IDL assets, and publish the GitHub Release.