### PR TITLE
chore: bump rust toolchain to 1.89.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 env:
-  RUST_VERSION: "1.85.1"
+  RUST_VERSION: "1.89.0"
   ANCHOR_VERSION: "0.31.1"
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RUST_VERSION: "1.85.1"
+  RUST_VERSION: "1.89.0"
   ANCHOR_VERSION: "0.31.1"
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Instead: stop, tell the human in plain language that this is a security fix and 
 
 ## Repository
 
-Anchor (0.31.1) workspace implementing a cross-chain intent protocol on Solana. Rust 1.85.1 (`rust-toolchain.toml`); release profile uses `lto = "fat"`.
+Anchor (0.31.1) workspace implementing a cross-chain intent protocol on Solana. Rust 1.89.0 (`rust-toolchain.toml`); release profile uses `lto = "fat"`.
 
 ## Build / test / lint
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ cargo install cargo-sort
 cargo install goldie
 
 # Set Rust toolchain
-rustup toolchain install 1.85.1
-rustup default 1.85.1
+rustup toolchain install 1.89.0
+rustup default 1.89.0
 ```
 
 ### Project Setup

--- a/integration-tests/tests/common/flash_fulfiller_context.rs
+++ b/integration-tests/tests/common/flash_fulfiller_context.rs
@@ -31,7 +31,7 @@ const FLASH_FULFILLER_HEAP_BYTES: u32 = 256 * 1024;
 pub struct FlashFulfiller<'a>(&'a mut Context);
 
 impl Context {
-    pub fn flash_fulfiller(&mut self) -> FlashFulfiller {
+    pub fn flash_fulfiller(&mut self) -> FlashFulfiller<'_> {
         FlashFulfiller(self)
     }
 }

--- a/integration-tests/tests/common/hyper_prover_context.rs
+++ b/integration-tests/tests/common/hyper_prover_context.rs
@@ -19,7 +19,7 @@ use crate::common::{sol_amount, Context, TransactionResult};
 pub struct HyperProver<'a>(&'a mut Context);
 
 impl Context {
-    pub fn hyper_prover(&mut self) -> HyperProver {
+    pub fn hyper_prover(&mut self) -> HyperProver<'_> {
         HyperProver(self)
     }
 }

--- a/integration-tests/tests/common/hyperlane_context.rs
+++ b/integration-tests/tests/common/hyperlane_context.rs
@@ -150,7 +150,7 @@ pub fn dispatched_message_pda(unique_message: &Pubkey) -> Pubkey {
 pub struct Hyperlane<'a>(&'a mut Context);
 
 impl Context {
-    pub fn hyperlane(&mut self) -> Hyperlane {
+    pub fn hyperlane(&mut self) -> Hyperlane<'_> {
         Hyperlane(self)
     }
 }

--- a/integration-tests/tests/common/local_prover_context.rs
+++ b/integration-tests/tests/common/local_prover_context.rs
@@ -16,7 +16,7 @@ use crate::common::{Context, TransactionResult};
 pub struct LocalProver<'a>(&'a mut Context);
 
 impl Context {
-    pub fn local_prover(&mut self) -> LocalProver {
+    pub fn local_prover(&mut self) -> LocalProver<'_> {
         LocalProver(self)
     }
 }

--- a/integration-tests/tests/common/portal_context.rs
+++ b/integration-tests/tests/common/portal_context.rs
@@ -19,7 +19,7 @@ use crate::common::{hyperlane_context, Context, TransactionResult, COMPUTE_UNIT_
 pub struct Portal<'a>(&'a mut Context);
 
 impl Context {
-    pub fn portal(&mut self) -> Portal {
+    pub fn portal(&mut self) -> Portal<'_> {
         Portal(self)
     }
 }

--- a/integration-tests/tests/common/proof_helper_context.rs
+++ b/integration-tests/tests/common/proof_helper_context.rs
@@ -57,7 +57,7 @@ pub fn igp_account_pda(salt: &[u8; 32]) -> Pubkey {
 pub struct ProofHelper<'a>(&'a mut Context);
 
 impl Context {
-    pub fn proof_helper(&mut self) -> ProofHelper {
+    pub fn proof_helper(&mut self) -> ProofHelper<'_> {
         ProofHelper(self)
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.89.0"


### PR DESCRIPTION
## What

Bumps the pinned Rust toolchain from **1.85.1 → 1.89.0** in `rust-toolchain.toml` and the `RUST_VERSION` env in both CI workflows (`pr-checks.yml`, `release.yml`), plus the matching docs in `README.md` and `CLAUDE.md`.

## Why

1.85.1 is ~15 months older than current rust-analyzer builds, so RA's proc-macro server (launched from the sysroot) panics with `span::hygiene::SyntaxContextId::from_u32` (exit 101) and no macro expansion works in editors. 1.89.0 is the rust version bundled in Solana platform-tools v1.52 (used by Anchor 0.31.1), and lands inside rust-analyzer's supported band.

## Deployed programs are unaffected

`cargo build-sbf`/`anchor build` compile on-chain bytecode with platform-tools' own rust, not this host pin. Verified empirically — a clean `anchor build` before and after the bump produces **byte-identical** `.so` for every program:

| program | sha256 (1.85.1 == 1.89.0) |
|---|---|
| portal | `a063f78…c7319` |
| local_prover | `8c471c9…8e41ae` |
| hyper_prover | `4cb56c3…961817` |
| flash_fulfiller | `519231e…3393d89` |
| proof_helper | `696e56b…d20e815` |
| dummy_ism | `c44409f…3f34c3b` |

## Validation (local, mirrors pr-checks)

- `anchor build` ✓
- `cargo build-sbf` mock-igp ✓
- `cargo +nightly fmt --all -- --check` ✓
- `cargo sort --workspace --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓ (no new lints)
- `cargo test --no-fail-fast` ✓ (all pass)