### PR TITLE
chore: add maschad to repository-owners reviewer group

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -5,6 +5,7 @@ reviewers:
     repository-owners:
       - re1ro
       - fish-sammy
+      - maschad
 files:
   '**':
     - repository-owners


### PR DESCRIPTION
Adds `maschad` to the `repository-owners` group in `.github/reviewers.yml`
so I get picked up by the existing `Auto Request Review` workflow
(`necojackarc/auto-request-review`).

`number_of_reviewers` is left at `1` — this just joins the existing random
rotation, it does not change review load for anyone else.

Tracked in [INF-482](https://linear.app/ecoprotocol/issue/INF-482/add-chad-to-auto-request-review-rotation-across-10-active-eco-repos)
