### PR TITLE
fix: unbreak CI, and stop the on-chain compiler depending on a cache

### DIFF
--- a/.github/actions/setup-anchor/action.yaml
+++ b/.github/actions/setup-anchor/action.yaml
@@ -4,10 +4,28 @@ inputs:
   anchor-version:
     description: 'Anchor CLI version to install'
     required: true
+  solana-version:
+    description: 'Solana CLI version to install (exact, no leading v)'
+    required: true
 
 runs:
   using: 'composite'
   steps:
+    # Native deps for building avm / anchor-cli from source. These used to arrive as a side
+    # effect of the upstream "latest stable" install script; declared here so they do not
+    # depend on what that script happens to do.
+    - name: Install build dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          build-essential pkg-config libssl-dev libudev-dev \
+          llvm libclang-dev protobuf-compiler libprotobuf-dev
+
+    # The cache key must contain the Solana version. Keyed on "stable" instead, an eviction
+    # silently swaps in whatever the installer serves that day -- including the platform-tools
+    # under ~/.cache/solana that compile the on-chain programs.
     - name: Cache Solana installation
       id: cache-solana
       uses: actions/cache@v4
@@ -15,13 +33,16 @@ runs:
         path: |
           ~/.cache/solana
           ~/.local/share/solana
-        key: solana-stable-${{ runner.os }}
+        key: solana-v${{ inputs.solana-version }}-${{ runner.os }}
 
+    # Pinned installer, not the "latest stable" convenience script: that one resolves to a
+    # moving target and also side-installs Anchor, surfpool, and Node, none of which this
+    # workflow uses (Anchor comes from avm below).
     - name: Install Solana CLI
       if: steps.cache-solana.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        curl --proto '=https' --tlsv1.2 -sSfL https://solana-install.solana.workers.dev | bash
+        sh -c "$(curl --proto '=https' --tlsv1.2 -sSfL https://release.anza.xyz/v${{ inputs.solana-version }}/install)"
         echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
 
     - name: Add Solana to PATH
@@ -81,3 +102,6 @@ runs:
         export PATH="$HOME/.local/share/solana/install/active_release/bin:$HOME/.avm/bin:$PATH"
         solana --version
         anchor --version
+        # Records the platform-tools/rustc this Solana CLI defaults to. Note `anchor build`
+        # may still resolve a different one -- assert-sbf-rustc.sh checks what it actually used.
+        cargo build-sbf --version

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 env:
-  RUST_VERSION: "1.89.0"
+  RUST_VERSION: "1.97.1"
   ANCHOR_VERSION: "0.31.1"
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,12 @@ on:
 env:
   RUST_VERSION: "1.97.1"
   ANCHOR_VERSION: "0.31.1"
+  # Exact Solana CLI version. This decides the platform-tools that compile the on-chain
+  # programs, so it is pinned rather than tracking "stable".
+  SOLANA_VERSION: "4.1.1"
+  # The rustc `anchor build` actually uses for the programs, asserted after every build.
+  # Changing this changes the compiler that produces deployed bytecode -- do it deliberately.
+  SBF_RUSTC_VERSION: "1.79.0-dev"
 
 jobs:
   format:
@@ -64,9 +70,13 @@ jobs:
         uses: ./.github/actions/setup-anchor
         with:
           anchor-version: ${{ env.ANCHOR_VERSION }}
+          solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Build Anchor programs
         run: anchor build
+
+      - name: Assert on-chain compiler
+        run: scripts/assert-sbf-rustc.sh ${{ env.SBF_RUSTC_VERSION }}
 
       - name: Build mock-igp (non-Anchor test program)
         run: cargo build-sbf --manifest-path integration-tests/programs/mock-igp/Cargo.toml --sbf-out-dir target/deploy
@@ -90,9 +100,13 @@ jobs:
         uses: ./.github/actions/setup-anchor
         with:
           anchor-version: ${{ env.ANCHOR_VERSION }}
+          solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Build Anchor programs
         run: anchor build
+
+      - name: Assert on-chain compiler
+        run: scripts/assert-sbf-rustc.sh ${{ env.SBF_RUSTC_VERSION }}
 
       - name: Build mock-igp (non-Anchor test program)
         run: cargo build-sbf --manifest-path integration-tests/programs/mock-igp/Cargo.toml --sbf-out-dir target/deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ concurrency:
 env:
   RUST_VERSION: "1.97.1"
   ANCHOR_VERSION: "0.31.1"
+  # Exact Solana CLI version. This decides the platform-tools that compile the on-chain
+  # programs, so it is pinned rather than tracking "stable".
+  SOLANA_VERSION: "4.1.1"
+  # The rustc `anchor build` actually uses for the programs, asserted after every build.
+  # Changing this changes the compiler that produces deployed bytecode -- do it deliberately.
+  SBF_RUSTC_VERSION: "1.79.0-dev"
 
 jobs:
   release:
@@ -34,6 +40,7 @@ jobs:
         uses: ./.github/actions/setup-anchor
         with:
           anchor-version: ${{ env.ANCHOR_VERSION }}
+          solana-version: ${{ env.SOLANA_VERSION }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -61,6 +68,10 @@ jobs:
           for program in portal hyper_prover local_prover flash_fulfiller proof_helper; do
             cp "target/idl/${program}.json" "dist/idl/mainnet/${program}.mainnet.json"
           done
+
+      - name: Assert on-chain compiler
+        if: steps.dry.outputs.new_release_published == 'true'
+        run: scripts/assert-sbf-rustc.sh ${{ env.SBF_RUSTC_VERSION }}
 
       - name: Build devnet IDLs
         if: steps.dry.outputs.new_release_published == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RUST_VERSION: "1.89.0"
+  RUST_VERSION: "1.97.1"
   ANCHOR_VERSION: "0.31.1"
 
 jobs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,15 @@ Instead: stop, tell the human in plain language that this is a security fix and 
 
 Anchor (0.31.1) workspace implementing a cross-chain intent protocol on Solana. Rust 1.97.1 (`rust-toolchain.toml`); release profile uses `lto = "fat"`.
 
+Two toolchains matter and they are not the same one. `rust-toolchain.toml` is the **host**
+compiler (clippy, tests, `avm`). The **on-chain** programs are compiled by the rustc inside
+Solana's platform-tools, which `anchor build` resolves itself — currently 1.79.0-dev, far
+older than the host. Anything in program code or in a dependency of `eco-svm-std` must
+compile under *that* rustc, so a new-ish stdlib method or a dependency raising its MSRV
+will break the on-chain build while the host build stays green. CI pins `SOLANA_VERSION`
+and asserts the SBF rustc after every build (`scripts/assert-sbf-rustc.sh`) so this cannot
+change silently.
+
 ## Build / test / lint
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Instead: stop, tell the human in plain language that this is a security fix and 
 
 ## Repository
 
-Anchor (0.31.1) workspace implementing a cross-chain intent protocol on Solana. Rust 1.89.0 (`rust-toolchain.toml`); release profile uses `lto = "fat"`.
+Anchor (0.31.1) workspace implementing a cross-chain intent protocol on Solana. Rust 1.97.1 (`rust-toolchain.toml`); release profile uses `lto = "fat"`.
 
 ## Build / test / lint
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,6 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "derive-new",
- "derive_more",
  "goldie",
 ]
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ cargo install cargo-sort
 cargo install goldie
 
 # Set Rust toolchain
-rustup toolchain install 1.89.0
-rustup default 1.89.0
+rustup toolchain install 1.97.1
+rustup default 1.97.1
 ```
 
 ### Project Setup

--- a/README.md
+++ b/README.md
@@ -114,9 +114,13 @@ source ~/.cargo/env
 
 #### 2. Install Solana CLI
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.18.26/install)"
+sh -c "$(curl -sSfL https://release.anza.xyz/v4.1.1/install)"
 export PATH="~/.local/share/solana/install/active_release/bin:$PATH"
 ```
+
+Use this exact version. CI pins it (`SOLANA_VERSION` in `.github/workflows/`) because it
+decides which platform-tools rustc compiles the on-chain programs; installing a different
+one locally can produce different bytecode than a release build.
 
 #### 3. Install Anchor CLI
 ```bash

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anchor-lang = { workspace = true }
 anchor-spl = { workspace = true }
 base64 = "0.22.1"
-derive_more = { version = "2.0.1", features = ["deref_mut"] }
+derive_more = { version = "2.0.1", features = ["deref", "deref_mut"] }
 dummy-ism = { workspace = true }
 eco-svm-std = { workspace = true }
 flash-fulfiller = { workspace = true, features = ["no-entrypoint"] }

--- a/packages/eco-svm-std/Cargo.toml
+++ b/packages/eco-svm-std/Cargo.toml
@@ -9,7 +9,6 @@ mainnet = []
 [dependencies]
 anchor-lang = { workspace = true }
 derive-new = { workspace = true }
-derive_more = { version = "2.0.1", features = ["deref"] }
 
 [dev-dependencies]
 goldie = { workspace = true }

--- a/packages/eco-svm-std/src/lib.rs
+++ b/packages/eco-svm-std/src/lib.rs
@@ -1,5 +1,4 @@
 use anchor_lang::prelude::*;
-use derive_more::Deref;
 
 pub mod account;
 pub mod prover;
@@ -11,10 +10,16 @@ pub const CHAIN_ID: u64 = 1399811150;
 
 const EVENT_AUTHORITY_SEED: &[u8] = b"__event_authority";
 
-#[derive(
-    AnchorSerialize, AnchorDeserialize, InitSpace, Deref, Clone, Copy, Debug, PartialEq, Eq,
-)]
+#[derive(AnchorSerialize, AnchorDeserialize, InitSpace, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Bytes32([u8; 32]);
+
+impl std::ops::Deref for Bytes32 {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl From<[u8; 32]> for Bytes32 {
     fn from(bytes: [u8; 32]) -> Self {

--- a/packages/eco-svm-std/src/prover.rs
+++ b/packages/eco-svm-std/src/prover.rs
@@ -56,13 +56,17 @@ impl ProofData {
             .collect()
     }
 
+    // `clippy::manual_is_multiple_of` (new in 1.97) wants `is_multiple_of` here, but that
+    // method does not exist in the rustc the Solana platform-tools ship, so the on-chain
+    // build cannot use it. Keep the `%` form until the platform-tools rustc catches up.
+    #[allow(clippy::manual_is_multiple_of)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
         require!(
             bytes.len() >= 8,
             anchor_lang::error::ErrorCode::InstructionDidNotDeserialize
         );
         require!(
-            (bytes.len() - 8).is_multiple_of(64),
+            (bytes.len() - 8) % 64 == 0,
             anchor_lang::error::ErrorCode::InstructionDidNotDeserialize
         );
 

--- a/packages/eco-svm-std/src/prover.rs
+++ b/packages/eco-svm-std/src/prover.rs
@@ -62,7 +62,7 @@ impl ProofData {
             anchor_lang::error::ErrorCode::InstructionDidNotDeserialize
         );
         require!(
-            (bytes.len() - 8) % 64 == 0,
+            (bytes.len() - 8).is_multiple_of(64),
             anchor_lang::error::ErrorCode::InstructionDidNotDeserialize
         );
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.97.1"

--- a/scripts/assert-sbf-rustc.sh
+++ b/scripts/assert-sbf-rustc.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Assert which rustc compiled the on-chain programs.
+#
+# `anchor build` does not use the `cargo-build-sbf` default toolchain. It resolves its own
+# platform-tools, downloads them under ~/.cache/solana, and links them as the `solana` rustup
+# toolchain. That resolution depends on the installed Solana CLI and on whatever is already
+# cached, so a cache eviction or an unpinned installer can silently change the compiler that
+# produces deployed bytecode -- with a green build either way.
+#
+# This makes that change loud instead of silent. Run it AFTER a build has run, since the
+# `solana` toolchain link is created during the build.
+#
+# Usage: scripts/assert-sbf-rustc.sh <expected-version>   e.g. 1.79.0-dev
+
+set -euo pipefail
+
+expected="${1:?usage: assert-sbf-rustc.sh <expected-version>}"
+
+if ! rustup toolchain list | grep -q '^solana'; then
+    echo "ERROR: no 'solana' rustup toolchain found." >&2
+    echo "This script must run after a step that builds the on-chain programs" >&2
+    echo "(anchor build / cargo build-sbf), which is what creates the link." >&2
+    exit 1
+fi
+
+# e.g. "rustc 1.79.0-dev" -> "1.79.0-dev"
+actual="$(rustup run solana rustc --version | awk '{print $2}')"
+
+echo "on-chain (SBF) rustc: ${actual}"
+
+if [[ "${actual}" != "${expected}" ]]; then
+    cat >&2 <<EOF
+
+ERROR: the on-chain compiler changed.
+
+  expected: ${expected}
+  actual:   ${actual}
+
+The rustc that compiles the deployed programs is not the one this repo pins. That changes
+the bytecode toolchain, so it must be a deliberate, reviewed decision -- not a side effect
+of a cache miss or an installer serving a new default.
+
+If the change is intended, update SBF_RUSTC_VERSION in .github/workflows/ and say why in
+the PR. If it is not, check SOLANA_VERSION and the Anchor version.
+EOF
+    exit 1
+fi


### PR DESCRIPTION
## 🔒 Security attestation (required)

- [x] This PR is **not** a security fix, **or**
- [ ] This is a security fix and a maintainer has **confirmed the affected code is not deployed on-chain** (and is not about to be), **or**
- [ ] This is the public merge of a fix coordinated via a private advisory, and the on-chain mitigation is **already deployed and verified live** (see [`SECURITY.md`](../SECURITY.md) → "Coordinated fix and disclosure").

---

## Description

Fixes [INF-484](https://linear.app/ecoprotocol/issue/INF-484/bug-eco-routes-svm-ci-red-since-2026-07-24-two-toolchain-breaks-rust).

**CI has been red on `main` since 2026-07-24** and nothing can be merged. There were **two independent breaks**, and investigating why the second one hid for three weeks turned up a third, more serious problem: which compiler produces on-chain bytecode was being decided by a cache.

Three commits, reviewable in order.

---

### 1. `bfb1aee` — the `1.89.0` pin can no longer build `avm`

Both `clippy` and `test` died in `Setup Anchor`, before running a single check. `avm`'s dependency graph now resolves `cargo-platform 0.3.3`, which declares `rust-version = 1.91`:

```
rustc 1.89.0 is not supported by the following package:
  cargo-platform@0.3.3 requires rustc 1.91
[ERROR] Anchor CLI installation failed.
##[error]Process completed with exit code 101
```

Nothing in this repo changed — an upstream transitive dep raised its MSRV past our pin.

**Fix:** host toolchain pin `1.89.0` → **`1.97.1`** (current stable, 2026-07-14) in `rust-toolchain.toml`, both workflows, `README.md`, `CLAUDE.md`. No `Cargo.toml` declares an MSRV, so those are all the pins.

### 2. `57ed47b` — Anchor's platform-tools rustc can't build `derive_more 2.1.1`

With break 1 fixed, `Setup Anchor` passed and the next failure appeared in `Build Anchor programs`:

```
error: rustc 1.79.0-dev is not supported by the following packages:
  derive_more@2.1.1 requires rustc 1.81.0
```

`anchor build` under Anchor 0.31.1 **resolves its own platform-tools** (rustc 1.79.0-dev) and links them as the `solana` rustup toolchain, ignoring the Solana CLI on `PATH` — CI has 4.1.1 installed and still gets 1.79. Latent since `derive_more` went to 2.x.

**Fix:** `eco-svm-std` used `derive_more` for exactly **one** `Deref` on the `Bytes32` newtype, so it's replaced with the impl the derive expands to and the dependency dropped:

```rust
impl std::ops::Deref for Bytes32 {
    type Target = [u8; 32];

    fn deref(&self) -> &Self::Target {
        &self.0
    }
}
```

This keeps **the compiler that produces on-chain bytecode unchanged** and removes the failure class from the SBF dep graph. Forcing newer platform-tools via `--tools-version` was rejected: it would change the on-chain compiler for funds-holding programs, and doesn't work cleanly anyway — Anchor forwards trailing args to its IDL build, which rejects them (`error: unexpected argument '--tools-version' found`).

`integration-tests` keeps `derive_more` (host-compiled, unaffected by the SBF MSRV), but it was relying on **cross-crate feature unification** for the `deref` feature that only `eco-svm-std` requested — removing that dep silently took `deref` away and broke 130+ call sites. It now declares `deref` explicitly. Pre-existing fragility, fixed in passing.

**On `is_multiple_of`:** commit 1 rewrote a divisibility check because clippy 1.97 adds `manual_is_multiple_of` and `-D warnings` fails on it. That method is stable since 1.87 but **does not exist in the platform-tools rustc**, so it breaks the on-chain build. The two gates directly conflict, so the `%` form is kept — identical to what is deployed — behind a targeted `#[allow]` with a comment.

### 3. `02a22b8` — the on-chain compiler depended on a cache

This is the one worth the most review attention. `Build Anchor programs` correctness rested on a GitHub Actions cache:

- the cache key was `solana-stable-<os>`, with **no version in it**, and
- the step installed whatever the upstream "latest stable" script served that day.

Since `anchor build` resolves platform-tools under `~/.cache/solana`, between those two **which rustc compiled the deployed programs was decided by whether a cache entry happened to be warm.** That is exactly how break 2 hid for three weeks: 2026-07-02 was green on a cache hit (`Cache restored from key: solana-stable-Linux`), the entry was evicted after 7 days idle, and the next run downloaded different platform-tools and failed. A silent change in the *other* direction — different bytecode from a still-green build — would have been worse and nothing would have caught it.

**Determinism:** pin `SOLANA_VERSION`, install from the versioned Anza installer instead of "latest", put the version in the cache key, and declare the native build deps explicitly (they previously arrived as a side effect of the install script, which also pulled in Anchor, surfpool, and Node that nothing here uses).

**Detection**, which is the part that actually protects the artifact: `scripts/assert-sbf-rustc.sh` checks the rustc `anchor build` really used — via the `solana` toolchain it links — against a pinned `SBF_RUSTC_VERSION`, and fails with an explanation if it moved. Wired into `clippy`, `test`, and `release`. Setup also now logs `cargo build-sbf --version`; previously a *passing* run told you nothing about what built your bytecode.

Detection is load-bearing because pinning alone doesn't fully close the hole — we don't directly control the platform-tools version Anchor resolves. Confirmed working in CI:

```
Cache not found for input keys: solana-v4.1.1-Linux
solana-cli 4.1.1 (src:19e19df5; feat:c763ae0a, client:Agave)
platform-tools v1.43
on-chain (SBF) rustc: 1.79.0-dev
```

**Pinned to what CI verified green (Solana 4.1.1 / SBF rustc 1.79.0-dev), not to a preferred version** — so this commit changes reproducibility, not the compiler.

## Blast radius

The only on-chain source change is a `Deref` impl byte-for-byte equivalent to the derive macro's output. The divisibility check is unchanged from `main`. The compiler producing on-chain bytecode is unchanged and now asserted. Everything else is CI config, docs, and a host-only test manifest.

## Reviewer notes

- `SBF_RUSTC_VERSION` is asserted, not derived. A legitimate Solana/Anchor upgrade will **fail CI** until the constant is updated. That is the intent: it turns a silent compiler swap into a reviewed diff.
- The `#[allow(clippy::manual_is_multiple_of)]` is a standing conflict, not a one-off — host clippy will keep wanting `is_multiple_of` until platform-tools' rustc reaches 1.87.
- **Recommended follow-up, not in this PR:** move off SBF rustc 1.79. It is old enough to keep breaking dependency upgrades — `derive_more` is the second instance — but that changes deployed bytecode and needs its own PR and verifiable-build consideration.

## Checklist

- [x] Code formatted (`cargo +nightly fmt`)
- [x] Imports sorted (`cargo sort --workspace`)
- [x] Clippy warnings resolved (`cargo clippy --all-targets -- -D warnings`) — clean across the workspace incl. `integration-tests`
- [x] All tests passing — `cargo test --no-fail-fast`: **184 passed, 0 failed**
- [x] `anchor build` verified against the rustc 1.79 platform-tools CI actually uses — all 6 programs + IDL build
- [x] `assert-sbf-rustc.sh` tested both directions — passes on match, exits 1 with explanation on mismatch
- [x] Workflows validated with `actionlint`
- [x] Golden files updated if needed — no golden output changed
- [x] Documentation updated — `CLAUDE.md` documents the host-vs-on-chain toolchain split; `README.md` Solana install aligned with the pin (was v1.18.26)