### PR TITLE
fix(hyper-prover): make handle idempotent for an already-recorded proof

### DIFF
--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -430,6 +430,30 @@ where
     }
 }
 
+/// How many times `expected` was emitted as an `event_cpi` event. Duplicate
+/// entries in one payload each emit, so consumers must upsert by intent hash
+/// rather than count — pinning the number here keeps that contract visible.
+pub fn count_cpi_events<E>(expected: E) -> impl Fn(TransactionMetadata) -> usize
+where
+    E: Event,
+{
+    let expected = expected.data();
+
+    move |actual: TransactionMetadata| {
+        actual
+            .inner_instructions
+            .iter()
+            .flat_map(|inner_ix_list| inner_ix_list.iter())
+            .filter(
+                |inner_instruction| match inner_instruction.instruction.data.get(8..) {
+                    Some(data) => data == expected,
+                    None => false,
+                },
+            )
+            .count()
+    }
+}
+
 pub fn contains_event_and_msg<E, M>(expected: E, msg: M) -> impl Fn(TransactionMetadata) -> bool
 where
     E: Event,

--- a/integration-tests/tests/handle.rs
+++ b/integration-tests/tests/handle.rs
@@ -560,6 +560,104 @@ fn handle_already_proven_other_destination_fail() {
     assert!(result.is_err_and(common::is_error(HyperProverError::IntentAlreadyProven)))
 }
 
+/// The same intent hash twice **in one payload**. `portal::prove` does not dedupe
+/// `intent_hashes`, so the runtime hands `mark_intent_hash_proven` the same
+/// aliased `AccountInfo` twice: the first entry initialises, the second takes the
+/// no-op branch. That relies on duplicate accounts within one instruction sharing
+/// a data buffer, so entry 1's write is visible to entry 2's read — load-bearing
+/// and otherwise unpinned. Before this change entry 2 hit `ConstraintZero` and
+/// reverted the whole message.
+#[test]
+fn handle_repeated_intent_hash_same_claimant_success() {
+    let mut ctx = setup();
+    let destination: u32 = random();
+    let claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let intent_hash: Bytes32 = random::<[u8; 32]>().into();
+    let sender = ctx.sender.pubkey();
+    let payload = ProofData::new(
+        destination.into(),
+        vec![
+            IntentHashClaimant::new(intent_hash, claimant),
+            IntentHashClaimant::new(intent_hash, claimant),
+        ],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload);
+
+    let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
+    assert!(result
+        .clone()
+        .is_ok_and(common::contains_cpi_event(prover::IntentProven::new(
+            intent_hash,
+            Pubkey::new_from_array(claimant.into()),
+            destination.into()
+        ),)));
+
+    // both entries emit, so a consumer counting events rather than upserting by
+    // intent hash would double-count
+    assert_eq!(
+        result.map(common::count_cpi_events(prover::IntentProven::new(
+            intent_hash,
+            Pubkey::new_from_array(claimant.into()),
+            destination.into()
+        ))),
+        Ok(2)
+    );
+
+    let proof_pda = Proof::pda(&intent_hash, &hyper_prover::ID).0;
+    let proof: ProofAccount = ctx.account(&proof_pda).unwrap();
+    assert_eq!(destination as u64, proof.0.destination);
+    assert_eq!(claimant, proof.0.claimant);
+}
+
+/// The intra-payload twin of `handle_already_proven_other_state_fail`. The
+/// source-side caller cannot currently construct it — `portal::prove` reads the
+/// claimant from the `FulfillMarker`, so both entries carry the same one — but
+/// that is a property of the caller, not of this guard, and being wrong here
+/// means a wrong proof rather than a duplicate log line.
+#[test]
+fn handle_repeated_intent_hash_other_claimant_fail() {
+    let mut ctx = setup();
+    let destination: u32 = random();
+    let claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let other_claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let intent_hash: Bytes32 = random::<[u8; 32]>().into();
+    let sender = ctx.sender.pubkey();
+    let payload = ProofData::new(
+        destination.into(),
+        vec![
+            IntentHashClaimant::new(intent_hash, claimant),
+            IntentHashClaimant::new(intent_hash, other_claimant),
+        ],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload);
+
+    let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
+    assert!(result.is_err_and(common::is_error(HyperProverError::IntentAlreadyProven)));
+    assert!(ctx
+        .account::<ProofAccount>(&Proof::pda(&intent_hash, &hyper_prover::ID).0)
+        .is_none());
+}
+
 #[test]
 fn handle_batch_with_already_proven_entry_success() {
     let mut ctx = setup();

--- a/integration-tests/tests/handle.rs
+++ b/integration-tests/tests/handle.rs
@@ -373,7 +373,14 @@ fn handle_already_proven_same_state_success() {
         ctx.hyper_prover()
             .handle_account_metas(destination, sender.to_bytes(), payload);
     let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
-    assert!(result.is_ok());
+    // the event repeats so a consumer that missed the first delivery still sees it
+    assert!(
+        result.is_ok_and(common::contains_cpi_event(prover::IntentProven::new(
+            intent_hash,
+            Pubkey::new_from_array(claimant.into()),
+            destination.into()
+        ),))
+    );
 
     let proof_pda = Proof::pda(&intent_hash, &hyper_prover::ID).0;
     let proof: ProofAccount = ctx.account(&proof_pda).unwrap();

--- a/integration-tests/tests/handle.rs
+++ b/integration-tests/tests/handle.rs
@@ -13,6 +13,7 @@ use portal::types::intent_hash;
 use rand::random;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signer::Signer;
+use solana_sdk::system_instruction::SystemError;
 
 use crate::common::sol_amount;
 
@@ -333,6 +334,42 @@ fn handle_invalid_pda_payer_fail() {
     *handle_account_metas.get_mut(2).unwrap() = AccountMeta::new(Pubkey::new_unique(), false);
     let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
     assert!(result.is_err_and(common::is_error(HyperProverError::InvalidPdaPayer)))
+}
+
+#[test]
+fn handle_unfunded_pda_payer_fail() {
+    // no `setup()`: `pda_payer` is left unfunded, so the proof init fails on rent
+    // inside the system-program CPI and surfaces that error rather than any
+    // prover-level one — the signal the `pda_payer` balance alarm keys on
+    let mut ctx = common::Context::default();
+    let sender = ctx.sender.pubkey();
+    ctx.hyper_prover()
+        .init(vec![sender.to_bytes().into()], Config::pda().0)
+        .unwrap();
+
+    let destination: u32 = random();
+    let claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let intent_hash: Bytes32 = random::<[u8; 32]>().into();
+    let payload = ProofData::new(
+        destination.into(),
+        vec![IntentHashClaimant::new(intent_hash, claimant)],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload);
+
+    let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
+    assert!(result.is_err_and(common::is_error(
+        SystemError::ResultWithNegativeLamports as u32
+    )));
 }
 
 #[test]

--- a/integration-tests/tests/handle.rs
+++ b/integration-tests/tests/handle.rs
@@ -429,6 +429,48 @@ fn handle_already_proven_other_state_fail() {
 }
 
 #[test]
+fn handle_already_proven_invalid_pda_payer_fail() {
+    let mut ctx = setup();
+    let destination: u32 = random();
+    let claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let intent_hash: Bytes32 = random::<[u8; 32]>().into();
+    let sender = ctx.sender.pubkey();
+    let payload = ProofData::new(
+        destination.into(),
+        vec![IntentHashClaimant::new(intent_hash, claimant)],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload.clone());
+    ctx.hyperlane()
+        .inbox_process(message, handle_account_metas)
+        .unwrap();
+
+    // a no-op entry still validates every account the instruction declares
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let mut handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload);
+    *handle_account_metas.get_mut(2).unwrap() = AccountMeta::new(Pubkey::new_unique(), false);
+    let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
+    assert!(result.is_err_and(common::is_error(HyperProverError::InvalidPdaPayer)))
+}
+
+#[test]
 fn handle_already_proven_other_destination_fail() {
     let mut ctx = setup();
     let destination: u32 = random();

--- a/integration-tests/tests/handle.rs
+++ b/integration-tests/tests/handle.rs
@@ -336,7 +336,7 @@ fn handle_invalid_pda_payer_fail() {
 }
 
 #[test]
-fn handle_already_proven_fail() {
+fn handle_already_proven_same_state_success() {
     let mut ctx = setup();
     let destination: u32 = random();
     let claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
@@ -373,7 +373,163 @@ fn handle_already_proven_fail() {
         ctx.hyper_prover()
             .handle_account_metas(destination, sender.to_bytes(), payload);
     let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
+    assert!(result.is_ok());
+
+    let proof_pda = Proof::pda(&intent_hash, &hyper_prover::ID).0;
+    let proof: ProofAccount = ctx.account(&proof_pda).unwrap();
+    assert_eq!(destination as u64, proof.0.destination);
+    assert_eq!(claimant, proof.0.claimant);
+}
+
+#[test]
+fn handle_already_proven_other_state_fail() {
+    let mut ctx = setup();
+    let destination: u32 = random();
+    let claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let intent_hash: Bytes32 = random::<[u8; 32]>().into();
+    let sender = ctx.sender.pubkey();
+    let proven_payload = ProofData::new(
+        destination.into(),
+        vec![IntentHashClaimant::new(intent_hash, claimant)],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        proven_payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), proven_payload);
+    ctx.hyperlane()
+        .inbox_process(message, handle_account_metas)
+        .unwrap();
+
+    // same intent hash, different claimant
+    let other_claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let payload = ProofData::new(
+        destination.into(),
+        vec![IntentHashClaimant::new(intent_hash, other_claimant)],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload);
+    let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
     assert!(result.is_err_and(common::is_error(HyperProverError::IntentAlreadyProven)))
+}
+
+#[test]
+fn handle_already_proven_other_destination_fail() {
+    let mut ctx = setup();
+    let destination: u32 = random();
+    let claimant: Bytes32 = Pubkey::new_unique().to_bytes().into();
+    let intent_hash: Bytes32 = random::<[u8; 32]>().into();
+    let sender = ctx.sender.pubkey();
+    let proven_payload = ProofData::new(
+        destination.into(),
+        vec![IntentHashClaimant::new(intent_hash, claimant)],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        proven_payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), proven_payload);
+    ctx.hyperlane()
+        .inbox_process(message, handle_account_metas)
+        .unwrap();
+
+    // same intent hash and claimant, different destination
+    let payload = ProofData::new(
+        u64::from(destination) + 1,
+        vec![IntentHashClaimant::new(intent_hash, claimant)],
+    )
+    .to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload);
+    let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
+    assert!(result.is_err_and(common::is_error(HyperProverError::IntentAlreadyProven)))
+}
+
+#[test]
+fn handle_batch_with_already_proven_entry_success() {
+    let mut ctx = setup();
+    let destination: u32 = random();
+    let sender = ctx.sender.pubkey();
+    let claimants: Vec<Bytes32> = (0..3)
+        .map(|_| Pubkey::new_unique().to_bytes().into())
+        .collect();
+    let intent_hashes: Vec<Bytes32> = (0..3).map(|_| random::<[u8; 32]>().into()).collect();
+    let entries: Vec<_> = intent_hashes
+        .iter()
+        .cloned()
+        .zip(claimants.iter().cloned())
+        .map(|(intent_hash, claimant)| IntentHashClaimant::new(intent_hash, claimant))
+        .collect();
+
+    // prove the middle entry on its own first
+    let single_payload = ProofData::new(destination.into(), vec![entries[1].clone()]).to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        single_payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), single_payload);
+    ctx.hyperlane()
+        .inbox_process(message, handle_account_metas)
+        .unwrap();
+
+    // the batch still lands, proving the entries the single delivery did not
+    let payload = ProofData::new(destination.into(), entries).to_bytes();
+    let message = create_hyperlane_message(
+        sender.to_bytes().into(),
+        destination,
+        CHAIN_ID.try_into().unwrap(),
+        hyper_prover::ID.to_bytes().into(),
+        payload.clone(),
+    );
+    let handle_account_metas =
+        ctx.hyper_prover()
+            .handle_account_metas(destination, sender.to_bytes(), payload);
+    let result = ctx.hyperlane().inbox_process(message, handle_account_metas);
+    assert!(result.is_ok());
+
+    intent_hashes
+        .into_iter()
+        .zip(claimants)
+        .for_each(|(intent_hash, claimant)| {
+            let proof_pda = Proof::pda(&intent_hash, &hyper_prover::ID).0;
+            let proof: ProofAccount = ctx.account(&proof_pda).unwrap();
+            assert_eq!(destination as u64, proof.0.destination);
+            assert_eq!(claimant, proof.0.claimant);
+        });
 }
 
 #[test]

--- a/programs/hyper-prover/src/instructions/handle.rs
+++ b/programs/hyper-prover/src/instructions/handle.rs
@@ -81,22 +81,21 @@ fn mark_intent_hash_proven<'info>(
 
     // A dispatched payload is immutable, so every redelivery carries the same
     // batch. Reaching the recorded state again is a no-op, and only a state
-    // that disagrees is an error — one entry must not decide the batch.
-    if let Some(recorded) = prover::Proof::try_from_account_info(proof)? {
-        require!(
+    // that disagrees is an error — one entry must not decide the batch. The
+    // event repeats either way: it asserts the recorded state rather than a
+    // transition, so a consumer that missed the first delivery still sees it.
+    match prover::Proof::try_from_account_info(proof)? {
+        Some(recorded) => require!(
             recorded.destination == destination && recorded.claimant == claimant,
             HyperProverError::IntentAlreadyProven
-        );
-
-        return Ok(());
+        ),
+        None => ProofAccount::from(prover::Proof::new(destination, claimant)).init(
+            proof,
+            &ctx.accounts.pda_payer,
+            &ctx.accounts.system_program,
+            &[&pda_payer_signer_seeds, &proof_signer_seeds],
+        )?,
     }
-
-    ProofAccount::from(prover::Proof::new(destination, claimant)).init(
-        proof,
-        &ctx.accounts.pda_payer,
-        &ctx.accounts.system_program,
-        &[&pda_payer_signer_seeds, &proof_signer_seeds],
-    )?;
 
     emit_cpi!(IntentProven::new(intent_hash, claimant, destination));
 

--- a/programs/hyper-prover/src/instructions/handle.rs
+++ b/programs/hyper-prover/src/instructions/handle.rs
@@ -72,6 +72,13 @@ fn mark_intent_hash_proven<'info>(
     require!(proof.key() == proof_pda, HyperProverError::InvalidProof);
     let proof_signer_seeds = [PROOF_SEED, intent_hash.as_ref(), &[bump]];
 
+    let (pda_payer_pda, bump) = pda_payer_pda();
+    require!(
+        ctx.accounts.pda_payer.key() == pda_payer_pda,
+        HyperProverError::InvalidPdaPayer
+    );
+    let pda_payer_signer_seeds = [PDA_PAYER_SEED, &[bump]];
+
     // A dispatched payload is immutable, so every redelivery carries the same
     // batch. Reaching the recorded state again is a no-op, and only a state
     // that disagrees is an error — one entry must not decide the batch.
@@ -83,13 +90,6 @@ fn mark_intent_hash_proven<'info>(
 
         return Ok(());
     }
-
-    let (pda_payer_pda, bump) = pda_payer_pda();
-    require!(
-        ctx.accounts.pda_payer.key() == pda_payer_pda,
-        HyperProverError::InvalidPdaPayer
-    );
-    let pda_payer_signer_seeds = [PDA_PAYER_SEED, &[bump]];
 
     ProofAccount::from(prover::Proof::new(destination, claimant)).init(
         proof,

--- a/programs/hyper-prover/src/instructions/handle.rs
+++ b/programs/hyper-prover/src/instructions/handle.rs
@@ -72,6 +72,18 @@ fn mark_intent_hash_proven<'info>(
     require!(proof.key() == proof_pda, HyperProverError::InvalidProof);
     let proof_signer_seeds = [PROOF_SEED, intent_hash.as_ref(), &[bump]];
 
+    // A dispatched payload is immutable, so every redelivery carries the same
+    // batch. Reaching the recorded state again is a no-op, and only a state
+    // that disagrees is an error — one entry must not decide the batch.
+    if let Some(recorded) = prover::Proof::try_from_account_info(proof)? {
+        require!(
+            recorded.destination == destination && recorded.claimant == claimant,
+            HyperProverError::IntentAlreadyProven
+        );
+
+        return Ok(());
+    }
+
     let (pda_payer_pda, bump) = pda_payer_pda();
     require!(
         ctx.accounts.pda_payer.key() == pda_payer_pda,
@@ -79,14 +91,12 @@ fn mark_intent_hash_proven<'info>(
     );
     let pda_payer_signer_seeds = [PDA_PAYER_SEED, &[bump]];
 
-    ProofAccount::from(prover::Proof::new(destination, claimant))
-        .init(
-            proof,
-            &ctx.accounts.pda_payer,
-            &ctx.accounts.system_program,
-            &[&pda_payer_signer_seeds, &proof_signer_seeds],
-        )
-        .map_err(|_| HyperProverError::IntentAlreadyProven)?;
+    ProofAccount::from(prover::Proof::new(destination, claimant)).init(
+        proof,
+        &ctx.accounts.pda_payer,
+        &ctx.accounts.system_program,
+        &[&pda_payer_signer_seeds, &proof_signer_seeds],
+    )?;
 
     emit_cpi!(IntentProven::new(intent_hash, claimant, destination));
 


### PR DESCRIPTION
## What

`hyper-prover::handle` treats an entry whose proof already records the **same** `destination` and `claimant` as a no-op instead of an error.

A dispatched Hyperlane payload is immutable, so every redelivery of a message carries the same batch of intents. Before this change `handle` mapped an already-initialized proof account to `IntentAlreadyProven` and returned `Err`, so a single entry that already held its recorded state decided the outcome for every other entry in the payload.

```rust
match prover::Proof::try_from_account_info(proof)? {
    Some(recorded) => require!(
        recorded.destination == destination && recorded.claimant == claimant,
        HyperProverError::IntentAlreadyProven
    ),
    None => ProofAccount::from(prover::Proof::new(destination, claimant)).init(...)?,
}

emit_cpi!(IntentProven::new(intent_hash, claimant, destination));
```

A recorded state that disagrees on **either** field is still `IntentAlreadyProven`, so nothing can silently overwrite or paper over a proof that says something different.

`IntentProven` is emitted on **every** delivery, including a no-op. It asserts the recorded state rather than a transition, so the event for an already-recorded entry is identical to the one emitted when it was first proven.

That duplicate does **not** come from redelivering the same message: the mailbox dedupes on the message hash, so a message that processed successfully is never delivered twice. It comes from two *distinct* messages whose batches overlap — exactly the case this change makes land instead of revert. Anything counting these rather than upserting by intent hash should upsert.

The check sits below the `pda_payer` validation and directly above the `init` it guards, so account validation stays unconditional — otherwise a no-op entry would return `Ok` without ever checking `pda_payer`, and the same message would validate differently depending on state.

The blanket `.map_err(|_| IntentAlreadyProven)` is dropped because the guard above now expresses the same thing precisely. It was not hiding other failures: `create_account`'s only locally-returned error is `ConstraintZero` (the account already exists), and every other path is an `invoke_signed(..)?` whose failure aborts the transaction rather than returning for us to remap. `handle_unfunded_pda_payer_fail` pins that — a `pda_payer` short on lamports surfaces `SystemError::ResultWithNegativeLamports`. Confirmed by cherry-picking the test onto `origin/main`, where it passes unchanged against the blanket `map_err`: a failed CPI aborts the transaction rather than returning `Err` for the caller to remap, so the mapping never saw it. No error-code contract changes on that path.

## Why it matters

Once a proof exists for an intent, `portal::refund` refuses while `withdraw` needs that proof, so a batch that cannot land is not merely a retry — it is a payout that never happens.

Concretely, the old behaviour turned one already-proven entry into a permanent wedge:

1. `portal::prove` is permissionless and keeps no dedupe state, so overlapping batches are dispatchable by anyone. Say `{C}` is dispatched separately and lands first.
2. A batch `{A, B, C}` is already dispatched and paid for. Its payload is fixed.
3. On delivery, `handle` hits `C`, errors, and the whole message reverts.
4. Redelivery replays the *same* payload, so it fails identically, forever. `A` and `B` never get proofs.
5. Their solvers cannot `withdraw`. `reward.deadline` passes, creators `refund`, and the delivery those solvers already performed goes unpaid.

No attacker is required — two honest keepers with overlapping sets produce it. And the entries that lose out are the ones with nothing wrong with them.

Idempotency is what makes the message redeliverable: step 3 becomes a no-op for `C` and `A`/`B` get their proofs on the retry.

## Why not `local-prover`

Deliberately unchanged. Its caller assembles the batch in the same transaction and can re-plan, so idempotency buys nothing. This also keeps `flash_fulfill`'s atomic prove → withdraw → fulfill path exactly as it is.

## Tests

`handle` goes 10 → 15:

| test | asserts |
|---|---|
| `handle_already_proven_same_state_success` | redelivering an identical entry succeeds, re-emits `IntentProven`, and leaves the proof intact |
| `handle_already_proven_other_state_fail` | same intent hash, **different claimant** → `IntentAlreadyProven` |
| `handle_already_proven_other_destination_fail` | same intent hash and claimant, **different destination** → `IntentAlreadyProven` |
| `handle_batch_with_already_proven_entry_success` | a 3-entry batch still lands after its middle entry was proven by an earlier single delivery, and all three proofs end up correct |
| `handle_already_proven_invalid_pda_payer_fail` | a no-op entry still validates every account the instruction declares |
| `handle_unfunded_pda_payer_fail` | an unfunded `pda_payer` surfaces the system-program rent failure, not a prover-level error (verified on `main` too) |
| `handle_repeated_intent_hash_same_claimant_success` | the same hash twice in **one** payload: entry 2 takes the no-op branch, and exactly two `IntentProven` events are emitted |
| `handle_repeated_intent_hash_other_claimant_fail` | the same hash twice with disagreeing claimants reverts the whole batch |

`handle_already_proven_fail` became `handle_already_proven_same_state_success` — that inversion is the behaviour change.

Each clause of the new guard is mutation-tested:

| mutation | result |
|---|---|
| remove the guard | 3 failures |
| drop the `claimant` clause | `..._other_state_fail` fails |
| drop the `destination` clause | `..._other_destination_fail` fails |
| hoist the guard above the `pda_payer` check | `..._invalid_pda_payer_fail` fails |
| suppress the event on the no-op path | `..._same_state_success` fails |

## Verification

`anchor build` clean, `cargo test --no-fail-fast` 33 binaries ok, `cargo clippy --all-targets -- -D warnings` clean, `cargo +nightly fmt --check` clean, `cargo sort --workspace --check` clean. The 8 `eco-svm-std` goldie failures under a workspace-wide run are the known local-only flake — 10/10 pass under `cargo test -p eco-svm-std`.

