### PR TITLE
fix(portal): mark Fund.payer mut so a sponsor payer can create ATAs

### DIFF
--- a/integration-tests/tests/common/portal_context.rs
+++ b/integration-tests/tests/common/portal_context.rs
@@ -62,45 +62,18 @@ impl Portal<'_> {
         allow_partial: bool,
         token_transfer_accounts: impl IntoIterator<Item = AccountMeta>,
     ) -> TransactionResult {
-        let args = portal::instructions::FundArgs {
+        let payer = self.payer.insecure_clone();
+
+        self.fund_intent_sponsored(
+            &payer,
+            &payer,
             destination,
-            route_hash,
             reward,
-            allow_partial,
-        };
-        let instruction = portal::instruction::Fund { args };
-        let accounts: Vec<_> = portal::accounts::Fund {
-            payer: self.payer.pubkey(),
-            funder: self.funder.pubkey(),
             vault,
-            token_program: anchor_spl::token::ID,
-            token_2022_program: anchor_spl::token_2022::ID,
-            associated_token_program: anchor_spl::associated_token::ID,
-            system_program: anchor_lang::system_program::ID,
-        }
-        .to_account_metas(None)
-        .into_iter()
-        .chain(token_transfer_accounts)
-        .collect();
-        let instruction = Instruction {
-            program_id: portal::ID,
-            accounts,
-            data: instruction.data(),
-        };
-
-        let transaction = Transaction::new(
-            &[&self.payer, &self.funder],
-            Message::new(
-                &[
-                    ComputeBudgetInstruction::set_compute_unit_limit(COMPUTE_UNIT_LIMIT),
-                    instruction,
-                ],
-                Some(&self.payer.pubkey()),
-            ),
-            self.svm.latest_blockhash(),
-        );
-
-        self.send_transaction(transaction)
+            route_hash,
+            allow_partial,
+            token_transfer_accounts,
+        )
     }
 
     /// Funds with a sponsor `payer` distinct from both `funder` and the

--- a/integration-tests/tests/common/portal_context.rs
+++ b/integration-tests/tests/common/portal_context.rs
@@ -77,10 +77,11 @@ impl Portal<'_> {
     }
 
     /// Funds with a sponsor `payer` distinct from both `funder` and the
-    /// transaction fee payer, using `to_account_metas` so the `payer` account's
-    /// writability reflects the `Fund` struct's constraints (i.e. an IDL-driven
-    /// client). Exercises the sponsored-relayer configuration the default
-    /// `fund_intent` builder cannot express (it pins payer to the fee payer).
+    /// transaction fee payer — the sponsored-relayer configuration the default
+    /// `fund_intent` builder cannot express, since it pins payer to the fee
+    /// payer. `payer`'s writability comes from `to_account_metas`, i.e. from the
+    /// `Fund` struct's constraints, so it models an IDL-driven client rather
+    /// than a hand-built meta.
     #[allow(clippy::too_many_arguments)]
     pub fn fund_intent_sponsored(
         &mut self,

--- a/integration-tests/tests/common/portal_context.rs
+++ b/integration-tests/tests/common/portal_context.rs
@@ -67,6 +67,7 @@ impl Portal<'_> {
         self.fund_intent_sponsored(
             &payer,
             &payer,
+            true,
             destination,
             reward,
             vault,
@@ -87,6 +88,7 @@ impl Portal<'_> {
         &mut self,
         payer: &Keypair,
         fee_payer: &Keypair,
+        payer_writable: bool,
         destination: u64,
         reward: Reward,
         vault: Pubkey,
@@ -112,6 +114,15 @@ impl Portal<'_> {
         }
         .to_account_metas(None)
         .into_iter()
+        .map(
+            |meta| match meta.pubkey == payer.pubkey() && !payer_writable {
+                // hand-built rather than derived: every other fund test takes the
+                // payer's writability from the same `Fund` struct it exercises, which
+                // is what made the missing `mut` invisible in the first place
+                true => AccountMeta::new_readonly(meta.pubkey, meta.is_signer),
+                false => meta,
+            },
+        )
         .chain(token_transfer_accounts)
         .collect();
         let instruction = Instruction {

--- a/integration-tests/tests/common/portal_context.rs
+++ b/integration-tests/tests/common/portal_context.rs
@@ -103,6 +103,64 @@ impl Portal<'_> {
         self.send_transaction(transaction)
     }
 
+    /// Funds with a sponsor `payer` distinct from both `funder` and the
+    /// transaction fee payer, using `to_account_metas` so the `payer` account's
+    /// writability reflects the `Fund` struct's constraints (i.e. an IDL-driven
+    /// client). Exercises the sponsored-relayer configuration the default
+    /// `fund_intent` builder cannot express (it pins payer to the fee payer).
+    #[allow(clippy::too_many_arguments)]
+    pub fn fund_intent_sponsored(
+        &mut self,
+        payer: &Keypair,
+        fee_payer: &Keypair,
+        destination: u64,
+        reward: Reward,
+        vault: Pubkey,
+        route_hash: Bytes32,
+        allow_partial: bool,
+        token_transfer_accounts: impl IntoIterator<Item = AccountMeta>,
+    ) -> TransactionResult {
+        let args = portal::instructions::FundArgs {
+            destination,
+            route_hash,
+            reward,
+            allow_partial,
+        };
+        let instruction = portal::instruction::Fund { args };
+        let accounts: Vec<_> = portal::accounts::Fund {
+            payer: payer.pubkey(),
+            funder: self.funder.pubkey(),
+            vault,
+            token_program: anchor_spl::token::ID,
+            token_2022_program: anchor_spl::token_2022::ID,
+            associated_token_program: anchor_spl::associated_token::ID,
+            system_program: anchor_lang::system_program::ID,
+        }
+        .to_account_metas(None)
+        .into_iter()
+        .chain(token_transfer_accounts)
+        .collect();
+        let instruction = Instruction {
+            program_id: portal::ID,
+            accounts,
+            data: instruction.data(),
+        };
+
+        let transaction = Transaction::new(
+            &[fee_payer, payer, &self.funder],
+            Message::new(
+                &[
+                    ComputeBudgetInstruction::set_compute_unit_limit(COMPUTE_UNIT_LIMIT),
+                    instruction,
+                ],
+                Some(&fee_payer.pubkey()),
+            ),
+            self.svm.latest_blockhash(),
+        );
+
+        self.send_transaction(transaction)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn refund_intent(
         &mut self,

--- a/integration-tests/tests/fund.rs
+++ b/integration-tests/tests/fund.rs
@@ -2,12 +2,15 @@ use std::iter;
 
 use anchor_lang::prelude::AccountMeta;
 use anchor_spl::associated_token::get_associated_token_address_with_program_id;
+use anchor_spl::token::spl_token;
 use portal::events::IntentFunded;
 use portal::instructions::PortalError;
 use portal::state;
 use portal::types::{intent_hash, TokenAmount};
 use rand::random;
+use solana_sdk::program_pack::Pack;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::rent::Rent;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 
@@ -148,8 +151,15 @@ fn fund_intent_tokens_distinct_sponsor_payer_success() {
         ctx.funder.pubkey(),
         false,
     ))));
-    // The sponsor paid the ATA rent (it is not the fee payer).
-    assert!(ctx.balance(&sponsor.pubkey()) < sponsor_balance);
+    // The sponsor paid exactly one vault ATA's rent per reward mint, and nothing
+    // else: it is neither the fee payer nor the funder.
+    let ata_rent = ctx
+        .get_sysvar::<Rent>()
+        .minimum_balance(spl_token::state::Account::LEN);
+    assert_eq!(
+        ctx.balance(&sponsor.pubkey()),
+        sponsor_balance - reward.tokens.len() as u64 * ata_rent
+    );
     reward.tokens.iter().for_each(|token| {
         assert_eq!(ctx.token_balance_ata(&token.token, &funder), 0);
         assert_eq!(

--- a/integration-tests/tests/fund.rs
+++ b/integration-tests/tests/fund.rs
@@ -1,5 +1,6 @@
 use std::iter;
 
+use anchor_lang::error::ErrorCode;
 use anchor_lang::prelude::AccountMeta;
 use anchor_spl::associated_token::get_associated_token_address_with_program_id;
 use anchor_spl::token::spl_token;
@@ -103,6 +104,40 @@ fn fund_intent_tokens_success() {
 /// writability is taken from the `Fund` struct constraints (an IDL-driven
 /// client). First-time token funding must create the vault ATA, charging the
 /// sponsor for rent.
+/// The contract this PR introduces: `#[account(mut)]` is checked in
+/// `try_accounts`, so a read-only sponsor `payer` is rejected before
+/// `fund_intent` runs — including on paths that create no ATA at all. Native-only
+/// funding is deliberately the shape here, since it is the case that succeeds
+/// today and would silently start succeeding again if the constraint were
+/// dropped.
+#[test]
+fn fund_intent_read_only_sponsor_payer_fail() {
+    let mut ctx = common::Context::default();
+    let (destination, _, mut reward) = ctx.rand_intent();
+    reward.tokens.clear();
+    let route_hash = random::<[u8; 32]>().into();
+    let vault_pda = state::vault_pda(&intent_hash(destination, &route_hash, &reward.hash())).0;
+    let funder = ctx.funder.pubkey();
+
+    let sponsor = Keypair::new();
+    ctx.airdrop(&sponsor.pubkey(), 1_000_000_000).unwrap();
+    ctx.airdrop(&funder, reward.native_amount).unwrap();
+    let fee_payer = ctx.payer.insecure_clone();
+
+    let result = ctx.portal().fund_intent_sponsored(
+        &sponsor,
+        &fee_payer,
+        false,
+        destination,
+        reward.clone(),
+        vault_pda,
+        route_hash,
+        true,
+        vec![],
+    );
+    assert!(result.is_err_and(common::is_error(ErrorCode::ConstraintMut)));
+}
+
 #[test]
 fn fund_intent_tokens_distinct_sponsor_payer_success() {
     let mut ctx = common::Context::default();
@@ -125,6 +160,7 @@ fn fund_intent_tokens_distinct_sponsor_payer_success() {
     let result = ctx.portal().fund_intent_sponsored(
         &sponsor,
         &fee_payer,
+        true,
         destination,
         reward.clone(),
         vault_pda,
@@ -158,7 +194,7 @@ fn fund_intent_tokens_distinct_sponsor_payer_success() {
         .minimum_balance(spl_token::state::Account::LEN);
     assert_eq!(
         ctx.balance(&sponsor.pubkey()),
-        sponsor_balance - reward.tokens.len() as u64 * ata_rent
+        sponsor_balance - reward.token_amounts().unwrap().len() as u64 * ata_rent
     );
     reward.tokens.iter().for_each(|token| {
         assert_eq!(ctx.token_balance_ata(&token.token, &funder), 0);

--- a/integration-tests/tests/fund.rs
+++ b/integration-tests/tests/fund.rs
@@ -8,6 +8,7 @@ use portal::state;
 use portal::types::{intent_hash, TokenAmount};
 use rand::random;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 
 pub mod common;
@@ -85,6 +86,70 @@ fn fund_intent_tokens_success() {
         false,
     ))));
     assert!(ctx.balance(&ctx.payer.pubkey()) < payer_balance);
+    reward.tokens.iter().for_each(|token| {
+        assert_eq!(ctx.token_balance_ata(&token.token, &funder), 0);
+        assert_eq!(
+            ctx.token_balance_ata(&token.token, &vault_pda),
+            token.amount
+        );
+    });
+}
+
+/// A sponsored-relayer configuration: the account paying ATA rent (`payer`) is
+/// distinct from both the token `funder` and the transaction fee payer, and its
+/// writability is taken from the `Fund` struct constraints (an IDL-driven
+/// client). First-time token funding must create the vault ATA, charging the
+/// sponsor for rent.
+#[test]
+fn fund_intent_tokens_distinct_sponsor_payer_success() {
+    let mut ctx = common::Context::default();
+    let (destination, _, reward) = ctx.rand_intent();
+    let route_hash = random::<[u8; 32]>().into();
+    let vault_pda = state::vault_pda(&intent_hash(destination, &route_hash, &reward.hash())).0;
+    let funder = ctx.funder.pubkey();
+    let token_program = &ctx.token_program.clone();
+
+    // Sponsor pays ATA rent; it is neither the funder nor the fee payer.
+    let sponsor = Keypair::new();
+    ctx.airdrop(&sponsor.pubkey(), 1_000_000_000).unwrap();
+    let sponsor_balance = ctx.balance(&sponsor.pubkey());
+    let fee_payer = ctx.payer.insecure_clone();
+
+    reward.tokens.iter().for_each(|token| {
+        ctx.airdrop_token_ata(&token.token, &funder, token.amount);
+    });
+
+    let result = ctx.portal().fund_intent_sponsored(
+        &sponsor,
+        &fee_payer,
+        destination,
+        reward.clone(),
+        vault_pda,
+        route_hash,
+        true,
+        reward.tokens.iter().flat_map(|token| {
+            let funder_token =
+                get_associated_token_address_with_program_id(&funder, &token.token, token_program);
+            let vault_ata = get_associated_token_address_with_program_id(
+                &vault_pda,
+                &token.token,
+                token_program,
+            );
+
+            vec![
+                AccountMeta::new(funder_token, false),
+                AccountMeta::new(vault_ata, false),
+                AccountMeta::new_readonly(token.token, false),
+            ]
+        }),
+    );
+    assert!(result.is_ok_and(common::contains_event(IntentFunded::new(
+        intent_hash(destination, &route_hash, &reward.hash()),
+        ctx.funder.pubkey(),
+        false,
+    ))));
+    // The sponsor paid the ATA rent (it is not the fee payer).
+    assert!(ctx.balance(&sponsor.pubkey()) < sponsor_balance);
     reward.tokens.iter().for_each(|token| {
         assert_eq!(ctx.token_balance_ata(&token.token, &funder), 0);
         assert_eq!(

--- a/programs/portal/src/instructions/fund.rs
+++ b/programs/portal/src/instructions/fund.rs
@@ -22,6 +22,7 @@ pub struct FundArgs {
 #[derive(Accounts)]
 #[instruction(args: FundArgs)]
 pub struct Fund<'info> {
+    #[account(mut)]
     pub payer: Signer<'info>,
     #[account(mut)]
     pub funder: Signer<'info>,


### PR DESCRIPTION
## Problem

`Fund.payer` funds vault ATA creation — `FundTokenContext` → `ensure_fundee_ata_initialized` → `associated_token::create` (`fund_context.rs:113`), which debits `payer` for rent. But `payer` was declared `Signer` **without** `#[account(mut)]` (`fund.rs:25`).

Creating an account requires the funding account to be writable at the parent-instruction level (a CPI can't escalate a read-only account to writable). So when `payer` is distinct from both the `funder` and the transaction fee payer — a sponsored-relayer setup — an IDL-driven client marks it read-only and the ATA-create CPI fails with `PrivilegeEscalation` ("writable privilege escalated"), blocking first-time token funding for that vault/mint.

Masked when `payer` equals the funder (`mut`) or the fee payer (always writable), or when the ATA already exists.

## Why it slipped through

- `payer` is never referenced by name in `fund.rs` — it's pulled in by the `From<&Context<Fund>>` impl in `fund_context.rs:24`, so the "this account is debited → must be `mut`" connection wasn't visible at the struct definition.
- `Fulfill` reaches the **same** `associated_token::create` path via its own `From<&Fulfill>` impl and *does* mark its `payer` `#[account(mut)]` (`fulfill.rs`) — so this was an inconsistency, not a design choice.
- Every existing fund test pins `payer` to the transaction fee payer (always writable), so the distinct-payer path was never exercised.

## Fix

Add `#[account(mut)]` to `Fund.payer`, matching `Fulfill`. One line.

## Test

Adds `fund_intent_tokens_distinct_sponsor_payer_success` and a `fund_intent_sponsored` builder that funds through a sponsor `payer` distinct from the funder and the fee payer, with `payer` writability derived from the `Fund` struct constraints (`to_account_metas`, i.e. exactly what an IDL client does). It fails with `PrivilegeEscalation` before the fix and passes after, asserting the vault ATA is created and the sponsor (not the fee payer) is debited for rent.

## Impact / severity

This also tightens the accounts struct, which is worth stating explicitly. `#[account(mut)]` compiles to an unconditional `is_writable` check in `try_accounts`, so it runs before `fund_intent` regardless of whether any ATA needs creating. A client passing a read-only `payer` distinct from both `funder` and the fee payer now fails `ConstraintMut` in two cases that succeed today: native-only funding, and token funding where every vault ATA already exists.

The regression is unreachable in practice — `payer == fee payer` cannot regress (the runtime forces the fee payer writable), `payer == funder` cannot regress (`funder` is already `mut`), and any client regenerating from the IDL marks `payer` writable — but it is a behaviour change, not purely a relaxation.


Availability only — a specific sponsored-payer client configuration reverts its own first-time funding tx; no fund loss, theft, or freeze, and it's client-side workaroundable (mark `payer` writable). Not a security-boundary change, so a normal PR rather than a private advisory.

