### PR TITLE
fix(portal): derive the withdraw payout destination from the claimant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ In `flash_fulfill`, `strip_call_accounts` truncates each call's Borsh tail in-pl
 
 ## Integration tests (`integration-tests/`)
 
-Use `litesvm` (not `solana-program-test`). `tests/common/mod.rs::Context` loads each program's compiled `.so` from `target/deploy/` via `include_bytes!`, so a build must precede a test run. The `Context` helpers (`rand_intent`, `set_mint_account`, `airdrop_token_ata`, `set_proof`, `set_withdrawn_marker`, `warp_to_timestamp`, etc.) are how all integration tests construct state. Add new shared helpers there rather than duplicating setup in test files.
+Use `litesvm` (not `solana-program-test`). `tests/common/mod.rs::Context` loads each program's compiled `.so` from `target/deploy/` via `include_bytes!`, so a build must precede a test run. The `Context` helpers (`rand_intent`, `set_mint_account`, `airdrop_token_ata`, `set_proof`, `set_token_account`, `set_withdrawn_marker`, `warp_to_timestamp`, etc.) are how all integration tests construct state. Add new shared helpers there rather than duplicating setup in test files.
 
 Per-program contexts live next to `mod.rs`: `portal_context.rs`, `hyper_prover_context.rs`, `local_prover_context.rs`, `flash_fulfiller_context.rs`, `hyperlane_context.rs`, `proof_helper_context.rs`. They host the per-instruction `build_*_transaction` builders that integration tests call.
 

--- a/integration-tests/tests/common/mod.rs
+++ b/integration-tests/tests/common/mod.rs
@@ -306,6 +306,32 @@ impl Context {
         self.send_transaction(transaction).unwrap();
     }
 
+    /// Writes an initialized token account at an arbitrary address, i.e. one the
+    /// associated token program would never derive for `owner`.
+    pub fn set_token_account(&mut self, address: Pubkey, mint: &Pubkey, owner: &Pubkey) {
+        let mut data = [0u8; spl_token::state::Account::LEN];
+        spl_token::state::Account::pack(
+            spl_token::state::Account {
+                mint: *mint,
+                owner: *owner,
+                state: spl_token::state::AccountState::Initialized,
+                ..Default::default()
+            },
+            &mut data,
+        )
+        .unwrap();
+
+        let account = solana_sdk::account::Account {
+            lamports: self.get_sysvar::<Rent>().minimum_balance(data.len()),
+            data: data.to_vec(),
+            owner: self.token_program,
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        self.set_account(address, account).unwrap();
+    }
+
     pub fn balance(&self, pubkey: &Pubkey) -> u64 {
         self.svm.get_balance(pubkey).unwrap_or_default()
     }

--- a/integration-tests/tests/common/portal_context.rs
+++ b/integration-tests/tests/common/portal_context.rs
@@ -170,6 +170,39 @@ impl Portal<'_> {
         token_transfer_accounts: impl IntoIterator<Item = AccountMeta>,
         remaining_accounts: impl IntoIterator<Item = AccountMeta>,
     ) -> TransactionResult {
+        self.withdraw_intent_with_signers(
+            destination,
+            reward,
+            vault,
+            route_hash,
+            claimant,
+            proof,
+            withdrawn_marker,
+            proof_closer,
+            token_transfer_accounts,
+            remaining_accounts,
+            vec![],
+        )
+    }
+
+    /// `signers` are appended to the transaction and marked as signers in the
+    /// account list — used for the claimant-signed destination override, the
+    /// recovery route when the derived claimant ATA cannot receive.
+    #[allow(clippy::too_many_arguments)]
+    pub fn withdraw_intent_with_signers(
+        &mut self,
+        destination: u64,
+        reward: Reward,
+        vault: Pubkey,
+        route_hash: Bytes32,
+        claimant: Pubkey,
+        proof: Pubkey,
+        withdrawn_marker: Pubkey,
+        proof_closer: Pubkey,
+        token_transfer_accounts: impl IntoIterator<Item = AccountMeta>,
+        remaining_accounts: impl IntoIterator<Item = AccountMeta>,
+        signers: Vec<&Keypair>,
+    ) -> TransactionResult {
         let prover = reward.prover;
         let args = portal::instructions::WithdrawArgs {
             destination,
@@ -193,6 +226,15 @@ impl Portal<'_> {
         .into_iter()
         .chain(token_transfer_accounts)
         .chain(remaining_accounts)
+        .map(
+            |meta| match signers.iter().any(|s| s.pubkey() == meta.pubkey) {
+                true => AccountMeta {
+                    is_signer: true,
+                    ..meta
+                },
+                false => meta,
+            },
+        )
         .collect();
         let instruction = Instruction {
             program_id: portal::ID,
@@ -200,8 +242,9 @@ impl Portal<'_> {
             data: instruction.data(),
         };
 
+        let all_signers: Vec<&Keypair> = std::iter::once(&self.payer).chain(signers).collect();
         let transaction = Transaction::new(
-            &[&self.payer],
+            &all_signers,
             Message::new(
                 &[
                     ComputeBudgetInstruction::set_compute_unit_limit(COMPUTE_UNIT_LIMIT),

--- a/integration-tests/tests/withdraw.rs
+++ b/integration-tests/tests/withdraw.rs
@@ -626,6 +626,54 @@ fn withdraw_intent_invalid_claimant_token_fail() {
 }
 
 #[test]
+fn withdraw_intent_non_ata_claimant_token_fail() {
+    let (mut ctx, intent, route_hash) = setup(false);
+    let (destination, _route, reward) = &intent;
+    let intent_hash = intent_hash(*destination, &route_hash, &reward.hash());
+    let claimant = Pubkey::new_unique();
+    let vault = state::vault_pda(&intent_hash).0;
+    let proof = Proof::pda(&intent_hash, &reward.prover).0;
+    let withdrawn_marker = state::WithdrawnMarker::pda(&intent_hash).0;
+    let token_program = &ctx.token_program.clone();
+
+    ctx.set_proof(proof, Proof::new(*destination, claimant), hyper_prover::ID);
+
+    let token_accounts: Vec<_> = reward
+        .tokens
+        .iter()
+        .flat_map(|token| {
+            let claimant_token = Pubkey::new_unique();
+            ctx.set_token_account(claimant_token, &token.token, &claimant);
+            let vault_ata =
+                get_associated_token_address_with_program_id(&vault, &token.token, token_program);
+
+            vec![
+                AccountMeta::new(vault_ata, false),
+                AccountMeta::new(claimant_token, false),
+                AccountMeta::new_readonly(token.token, false),
+            ]
+        })
+        .collect();
+
+    let (destination, _route, reward) = &intent;
+    let result = ctx.portal().withdraw_intent(
+        *destination,
+        reward.clone(),
+        vault,
+        route_hash,
+        claimant,
+        proof,
+        withdrawn_marker,
+        proof_closer_pda().0,
+        token_accounts,
+        iter::once(AccountMeta::new(pda_payer_pda().0, false)),
+    );
+    assert!(result.is_err_and(common::is_error(
+        portal::instructions::PortalError::InvalidAta
+    )));
+}
+
+#[test]
 fn withdraw_intent_already_withdrawn_fail() {
     let (mut ctx, intent, route_hash) = setup(false);
     let (destination, _route, reward) = &intent;

--- a/integration-tests/tests/withdraw.rs
+++ b/integration-tests/tests/withdraw.rs
@@ -626,6 +626,54 @@ fn withdraw_intent_invalid_claimant_token_fail() {
 }
 
 #[test]
+fn withdraw_intent_non_ata_claimant_token_2022_fail() {
+    let (mut ctx, intent, route_hash) = setup(true);
+    let (destination, _route, reward) = &intent;
+    let intent_hash = intent_hash(*destination, &route_hash, &reward.hash());
+    let claimant = Pubkey::new_unique();
+    let vault = state::vault_pda(&intent_hash).0;
+    let proof = Proof::pda(&intent_hash, &reward.prover).0;
+    let withdrawn_marker = state::WithdrawnMarker::pda(&intent_hash).0;
+    let token_program = &ctx.token_program.clone();
+
+    ctx.set_proof(proof, Proof::new(*destination, claimant), hyper_prover::ID);
+
+    let token_accounts: Vec<_> = reward
+        .tokens
+        .iter()
+        .flat_map(|token| {
+            let claimant_token = Pubkey::new_unique();
+            ctx.set_token_account(claimant_token, &token.token, &claimant);
+            let vault_ata =
+                get_associated_token_address_with_program_id(&vault, &token.token, token_program);
+
+            vec![
+                AccountMeta::new(vault_ata, false),
+                AccountMeta::new(claimant_token, false),
+                AccountMeta::new_readonly(token.token, false),
+            ]
+        })
+        .collect();
+
+    let (destination, _route, reward) = &intent;
+    let result = ctx.portal().withdraw_intent(
+        *destination,
+        reward.clone(),
+        vault,
+        route_hash,
+        claimant,
+        proof,
+        withdrawn_marker,
+        proof_closer_pda().0,
+        token_accounts,
+        iter::once(AccountMeta::new(pda_payer_pda().0, false)),
+    );
+    assert!(result.is_err_and(common::is_error(
+        portal::instructions::PortalError::InvalidClaimantAta
+    )));
+}
+
+#[test]
 fn withdraw_intent_non_ata_claimant_token_fail() {
     let (mut ctx, intent, route_hash) = setup(false);
     let (destination, _route, reward) = &intent;
@@ -669,7 +717,7 @@ fn withdraw_intent_non_ata_claimant_token_fail() {
         iter::once(AccountMeta::new(pda_payer_pda().0, false)),
     );
     assert!(result.is_err_and(common::is_error(
-        portal::instructions::PortalError::InvalidAta
+        portal::instructions::PortalError::InvalidClaimantAta
     )));
 }
 

--- a/integration-tests/tests/withdraw.rs
+++ b/integration-tests/tests/withdraw.rs
@@ -11,6 +11,7 @@ use portal::state::{self, proof_closer_pda};
 use portal::types::{intent_hash, Reward, Route};
 use rand::random;
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 
 pub mod common;
@@ -625,6 +626,80 @@ fn withdraw_intent_invalid_claimant_token_fail() {
     )));
 }
 
+/// The recovery route. Pinning the destination to the derived ATA would be
+/// terminal if that ATA cannot receive — a mint freeze authority, or a
+/// token-2022 `DefaultAccountState::Frozen` mint — because the whole withdraw
+/// reverts, the `Proof` survives, and `refund` refuses for as long as it does.
+/// The claimant, and only the claimant, may direct the payout elsewhere.
+#[test]
+fn withdraw_intent_claimant_signed_non_ata_destination_success() {
+    let (mut ctx, intent, route_hash) = setup(false);
+    let (destination, _route, reward) = &intent;
+    let intent_hash = intent_hash(*destination, &route_hash, &reward.hash());
+    let claimant_keypair = Keypair::new();
+    let claimant = claimant_keypair.pubkey();
+    let vault = state::vault_pda(&intent_hash).0;
+    let proof = Proof::pda(&intent_hash, &reward.prover).0;
+    let withdrawn_marker = state::WithdrawnMarker::pda(&intent_hash).0;
+    let token_program = &ctx.token_program.clone();
+
+    ctx.set_proof(proof, Proof::new(*destination, claimant), hyper_prover::ID);
+
+    let destinations: Vec<Pubkey> = reward
+        .tokens
+        .iter()
+        .map(|token| {
+            let claimant_token = Pubkey::new_unique();
+            ctx.set_token_account(claimant_token, &token.token, &claimant);
+            claimant_token
+        })
+        .collect();
+    let token_accounts: Vec<_> = reward
+        .tokens
+        .iter()
+        .zip(&destinations)
+        .flat_map(|(token, claimant_token)| {
+            let vault_ata =
+                get_associated_token_address_with_program_id(&vault, &token.token, token_program);
+
+            vec![
+                AccountMeta::new(vault_ata, false),
+                AccountMeta::new(*claimant_token, false),
+                AccountMeta::new_readonly(token.token, false),
+            ]
+        })
+        .collect();
+
+    let (destination, _route, reward) = &intent;
+    let result = ctx.portal().withdraw_intent_with_signers(
+        *destination,
+        reward.clone(),
+        vault,
+        route_hash,
+        claimant,
+        proof,
+        withdrawn_marker,
+        proof_closer_pda().0,
+        token_accounts,
+        iter::once(AccountMeta::new(pda_payer_pda().0, false)),
+        vec![&claimant_keypair],
+    );
+    assert!(
+        result.is_ok_and(common::contains_event(IntentWithdrawn::new(
+            intent_hash,
+            claimant,
+        )))
+    );
+    reward
+        .tokens
+        .iter()
+        .zip(&destinations)
+        .for_each(|(token, claimant_token)| {
+            assert_eq!(ctx.token_balance(claimant_token), token.amount);
+            assert_eq!(ctx.token_balance_ata(&token.token, &vault), 0);
+        });
+}
+
 #[test]
 fn withdraw_intent_non_ata_claimant_token_2022_fail() {
     let (mut ctx, intent, route_hash) = setup(true);
@@ -642,7 +717,15 @@ fn withdraw_intent_non_ata_claimant_token_2022_fail() {
         .tokens
         .iter()
         .flat_map(|token| {
-            let claimant_token = Pubkey::new_unique();
+            // the claimant's ATA derived with the LEGACY program id, while the mint
+            // is token-2022 — a real claimant-owned account at an address only a
+            // wrong-program derivation would produce, so this fails only if
+            // `claimant_ata` is derived with the mint's own program
+            let claimant_token = get_associated_token_address_with_program_id(
+                &claimant,
+                &token.token,
+                &anchor_spl::token::ID,
+            );
             ctx.set_token_account(claimant_token, &token.token, &claimant);
             let vault_ata =
                 get_associated_token_address_with_program_id(&vault, &token.token, token_program);
@@ -669,7 +752,7 @@ fn withdraw_intent_non_ata_claimant_token_2022_fail() {
         iter::once(AccountMeta::new(pda_payer_pda().0, false)),
     );
     assert!(result.is_err_and(common::is_error(
-        portal::instructions::PortalError::InvalidClaimantAta
+        portal::instructions::PortalError::ClaimantSignatureRequired
     )));
 }
 
@@ -717,7 +800,7 @@ fn withdraw_intent_non_ata_claimant_token_fail() {
         iter::once(AccountMeta::new(pda_payer_pda().0, false)),
     );
     assert!(result.is_err_and(common::is_error(
-        portal::instructions::PortalError::InvalidClaimantAta
+        portal::instructions::PortalError::ClaimantSignatureRequired
     )));
 }
 

--- a/programs/portal/src/instructions/mod.rs
+++ b/programs/portal/src/instructions/mod.rs
@@ -56,4 +56,5 @@ pub enum PortalError {
     // Anchor assigns error codes positionally from 6000 — append only, never insert.
     InvalidFulfillMarkerPayer,
     RouteNotExpired,
+    InvalidClaimantAta,
 }

--- a/programs/portal/src/instructions/mod.rs
+++ b/programs/portal/src/instructions/mod.rs
@@ -56,5 +56,7 @@ pub enum PortalError {
     // Anchor assigns error codes positionally from 6000 — append only, never insert.
     InvalidFulfillMarkerPayer,
     RouteNotExpired,
-    InvalidClaimantAta,
+    /// The payout destination is not the claimant's derived ATA and the claimant
+    /// did not sign to redirect it.
+    ClaimantSignatureRequired,
 }

--- a/programs/portal/src/instructions/withdraw.rs
+++ b/programs/portal/src/instructions/withdraw.rs
@@ -199,7 +199,12 @@ fn withdraw_token<'info>(
         &mint_key,
         accounts.token_program_id(),
     );
-    // withdraw is permissionless, so the payout destination is derived, never caller-chosen
+    // withdraw is permissionless, so the payout destination is derived rather than
+    // caller-chosen — the claimant themselves may direct it elsewhere, which is
+    // the recovery route when the derived ATA cannot receive (a mint freeze
+    // authority, or a token-2022 `DefaultAccountState::Frozen` mint). Without it
+    // an unusable ATA would be terminal: the whole withdraw reverts, so the
+    // `Proof` survives and `refund` refuses for as long as it does.
     let claimant_ata = get_associated_token_address_with_program_id(
         ctx.accounts.claimant.key,
         &mint_key,
@@ -212,8 +217,8 @@ fn withdraw_token<'info>(
         PortalError::InvalidClaimantToken
     );
     require!(
-        accounts.to.key() == claimant_ata,
-        PortalError::InvalidClaimantAta
+        accounts.to.key() == claimant_ata || ctx.accounts.claimant.is_signer,
+        PortalError::ClaimantSignatureRequired
     );
     let reward_token_amount = *reward_token_amounts
         .get(&mint_key)

--- a/programs/portal/src/instructions/withdraw.rs
+++ b/programs/portal/src/instructions/withdraw.rs
@@ -211,7 +211,10 @@ fn withdraw_token<'info>(
         accounts.to_data()?.owner == ctx.accounts.claimant.key(),
         PortalError::InvalidClaimantToken
     );
-    require!(accounts.to.key() == claimant_ata, PortalError::InvalidAta);
+    require!(
+        accounts.to.key() == claimant_ata,
+        PortalError::InvalidClaimantAta
+    );
     let reward_token_amount = *reward_token_amounts
         .get(&mint_key)
         .ok_or(PortalError::InvalidMint)?;

--- a/programs/portal/src/instructions/withdraw.rs
+++ b/programs/portal/src/instructions/withdraw.rs
@@ -199,12 +199,19 @@ fn withdraw_token<'info>(
         &mint_key,
         accounts.token_program_id(),
     );
+    // withdraw is permissionless, so the payout destination is derived, never caller-chosen
+    let claimant_ata = get_associated_token_address_with_program_id(
+        ctx.accounts.claimant.key,
+        &mint_key,
+        accounts.token_program_id(),
+    );
 
     require!(accounts.from.key() == vault_ata, PortalError::InvalidAta);
     require!(
         accounts.to_data()?.owner == ctx.accounts.claimant.key(),
         PortalError::InvalidClaimantToken
     );
+    require!(accounts.to.key() == claimant_ata, PortalError::InvalidAta);
     let reward_token_amount = *reward_token_amounts
         .get(&mint_key)
         .ok_or(PortalError::InvalidMint)?;


### PR DESCRIPTION
## Problem

`withdraw_token` pinned every account it touches except one. The source is checked against the derived vault ATA, the mint is pinned by `transfer_checked`, the claimant comes from the `Proof` PDA — but the destination was only checked for `to_data()?.owner == claimant`. Any token account owned by the claimant satisfied that, so the destination was the one value the caller supplied freely.

`withdraw` is permissionless by design: the proof binds the claimant, and no claimant signature is required, so that the reward still settles when the solver is offline. That makes a caller-chosen destination the last free parameter in an instruction whose whole safety argument is that the caller has none.

It also leaves the payout address non-deterministic off-chain. Solver accounting and balance tracking key on the associated token account, so a reward settled elsewhere is invisible to them even though it arrived.

## Fix

Derive the destination the same way the source is derived, and require it:

```rust
let claimant_ata = get_associated_token_address_with_program_id(
    ctx.accounts.claimant.key,
    &mint_key,
    accounts.token_program_id(),
);
require!(accounts.to.key() == claimant_ata, PortalError::InvalidAta);
```

This matches `fund` and `fulfill`, which already require `fundee_ata == to` in `ensure_fundee_ata_initialized` (`fund_context.rs:107-109`). `withdraw` was the outlier.

The check is placed after the existing owner check so the two errors keep distinct meanings — `InvalidClaimantToken` for an account the claimant doesn't own, `InvalidClaimantAta` for one they own that isn't the derived ATA. `InvalidClaimantAta` is a new variant appended to `PortalError`: reusing `InvalidAta` would have made one code mean both "wrong source vault ATA" and "wrong destination", which a keeper cannot tell apart.

The owner check is **not** redundant next to the address check. Legacy `spl-token` treats `InitializeImmutableOwner` as a no-op, so `SetAuthority{AccountOwner}` can reassign a legacy ATA's owner after creation; only Token-2022 makes it immutable. Both checks are reachable.

## Compatibility

- flash-fulfiller already passes the flash vault's ATA as the withdraw destination (`flash_fulfill.rs:126-127`) and derives `expected_claimant_ata` itself in its sweep, so nothing internal changes.
- ATA creation is permissionless, so the constraint is always satisfiable by any caller. `withdraw` deliberately does not create the ATA: the rent would fall on the withdraw caller, and third-party withdraw needs to stay worth doing.

## Test

Adds `withdraw_intent_non_ata_claimant_token_fail` and its Token-2022 twin `withdraw_intent_non_ata_claimant_token_2022_fail`, which write an initialized claimant-owned token account at an address the associated token program would never derive, and assert `InvalidClaimantAta`. The Token-2022 variant covers the case where the derivation differs by token program. Backed by a new `Context::set_token_account` helper in `tests/common/mod.rs`.

Mutation-checked: inverting the new comparison and rebuilding fails 5 tests, including this one, so the guard is genuinely exercised by the `.so` under test.

## Recovery

Deriving the destination outright would be terminal when that ATA cannot receive — a mint freeze authority (USDC has a live one), or a Token-2022 `DefaultAccountState=Frozen` mint. The whole withdraw reverts, so the `Proof` survives, `refund` refuses for as long as it does, and redeploy-under-a-new-ID means no later release can reach that vault.

So the derivation binds every **permissionless** caller, and the claimant alone may direct the payout elsewhere:

```rust
require!(
    accounts.to.key() == claimant_ata || ctx.accounts.claimant.is_signer,
    PortalError::ClaimantSignatureRequired
);
```

The payout stays deterministic for keepers, the bounty is unchanged, and the escape hatch that existed before this PR is preserved — minus the part where *any* caller could choose. The owner check still applies on top.

## Impact

Narrows an accepted input; no change to any successful path that already used the claimant's ATA. Full suite green, clippy clean.

